### PR TITLE
resource(.bcolz) with ndarray dshape creates nd carray

### DIFF
--- a/into/backends/bcolz.py
+++ b/into/backends/bcolz.py
@@ -81,7 +81,8 @@ def resource_bcolz(uri, dshape=None, **kwargs):
         dshape = datashape.dshape(dshape)
 
         dt = datashape.to_numpy_dtype(dshape)
-        x = np.empty(shape=(0,), dtype=dt)
+        shape = (0,) + tuple(map(int, dshape.shape[1:]))
+        x = np.empty(shape=shape, dtype=dt)
 
         kwargs = keyfilter(keywords.__contains__, kwargs)
         expectedlen = kwargs.pop('expectedlen',

--- a/into/backends/tests/test_bcolz.py
+++ b/into/backends/tests/test_bcolz.py
@@ -128,6 +128,16 @@ def test_resource_ctable_correctly_infers_length():
         assert get_expectedlen(r) == 100
 
 
+def test_resource_nd_carray():
+    with tmpfile('.bcolz') as fn:
+        os.remove(fn)
+        r = resource(fn, dshape='10 * 10 * 10 * int32')
+
+        assert isinstance(r, carray)
+        assert r.dtype == 'i4'
+        assert r.shape[1:] == (10, 10)
+
+
 y = np.array([('Alice', 100), ('Bob', 200)],
             dtype=[('name', 'S7'), ('amount', 'i4')])
 


### PR DESCRIPTION
```python
In [1]: from into import resource, dshape

In [2]: resource('foo.bcolz', dshape=dshape('10 * 10 * 10 * int32')).shape
Out[2]: (0, 10, 10)
```