### PR TITLE
Support HDFStore - take two

### DIFF
--- a/into/__init__.py
+++ b/into/__init__.py
@@ -12,6 +12,7 @@ from .drop import drop
 from .chunks import chunks, Chunks
 from datashape import discover, dshape
 from collections import Iterator
+import numpy as np
 
 try:
      from .backends.pandas import pd

--- a/into/__init__.py
+++ b/into/__init__.py
@@ -26,6 +26,10 @@ try:
 except:
     pass
 try:
+     from .backends.hdfstore import HDFStore
+except:
+    pass
+try:
      from .backends.pytables import tables
 except:
     pass

--- a/into/backends/h5py.py
+++ b/into/backends/h5py.py
@@ -124,8 +124,8 @@ def h5py_to_numpy_chunks(dset, chunksize=2**20, **kwargs):
     return chunks(np.ndarray)(load)
 
 
-@resource.register('.+\.hdf5')
-def resource_hdf5(uri, datapath=None, dshape=None, **kwargs):
+@resource.register('h5py://.+', priority=11)
+def resource_h5py(uri, datapath=None, dshape=None, **kwargs):
     f = h5py.File(uri)
     olddatapath = datapath
     if dshape is not None:
@@ -141,6 +141,10 @@ def resource_hdf5(uri, datapath=None, dshape=None, **kwargs):
     else:
         return f
 
+
+@resource.register('.+\.(hdf5|h5)')
+def resource_hdf5(*args, **kwargs):
+    return resource_h5py(*args, **kwargs)
 
 @dispatch((h5py.Group, h5py.Dataset))
 def drop(h):

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -27,10 +27,15 @@ def discover_hdfstore_storer(storer):
     return n * measure
 
 
-@convert.register(chunks(pd.DataFrame), HDFDataset)
+@convert.register(chunks(pd.DataFrame), pd.io.pytables.AppendableFrameTable)
 def hdfstore_to_chunks_dataframes(data, chunksize=1000000, **kwargs):
     return chunks(pd.DataFrame)(data.parent.select(data.pathname, chunksize=chunksize))
 
+
+@convert.register(pd.DataFrame, (pd.io.pytables.AppendableFrameTable,
+                                 pd.io.pytables.FrameFixed))
+def hdfstore_to_chunks_dataframes(data, **kwargs):
+    return data.read()
 
 from collections import namedtuple
 

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -75,3 +75,6 @@ def append_chunks_dataframe_to_hdfstore(store, c, **kwargs):
 @append.register((pd.io.pytables.Fixed, EmptyHDFStoreDataset), object)
 def append_object_to_hdfstore(store, o, **kwargs):
     return append(store, convert(chunks(pd.DataFrame), o, **kwargs), **kwargs)
+
+
+ooc_types |= set(HDFDataset)

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -34,7 +34,7 @@ from collections import namedtuple
 
 EmptyHDFStoreDataset = namedtuple('EmptyHDFStoreDataset', 'parent,pathname,dshape')
 
-@resource.register('hdfstore://.+\.hdf5', priority=11)
+@resource.register('hdfstore://.+', priority=11)
 def resource_hdfstore(uri, datapath=None, dshape=None, **kwargs):
     # TODO:
     # 1. Support nested datashapes (e.g. groups)

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import, division, print_function
+
+import pandas as pd
+
+import datashape
+from datashape import discover
+from ..append import append
+from ..convert import convert, ooc_types
+from ..chunks import chunks, Chunks
+from ..resource import resource
+
+
+HDFDataset = (pd.io.pytables.AppendableFrameTable, pd.io.pytables.FrameFixed)
+
+@discover.register(pd.HDFStore)
+def discover_hdfstore(f):
+    return discover(dict((k.lstrip('/'), f.get_storer(k)) for k in f.keys()))
+
+
+@discover.register(pd.io.pytables.Fixed)
+def discover_hdfstore_storer(storer):
+    f = storer.parent
+    n = storer.shape
+    measure = discover(f.select(storer.pathname, start=0, stop=10)).measure
+    return n * measure
+
+
+@convert.register(chunks(pd.DataFrame), HDFDataset)
+def hdfstore_to_chunks_dataframes(data, chunksize=1000000, **kwargs):
+    return chunks(pd.DataFrame)(data.parent.select(data.pathname, chunksize=chunksize))
+
+
+from collections import namedtuple
+
+EmptyHDFStoreDataset = namedtuple('EmptyHDFStoreDataset', 'parent,pathname,dshape')
+
+@resource.register('hdfstore://.+\.hdf5', priority=11)
+def resource_hdfstore(uri, datapath=None, dshape=None, **kwargs):
+    # TODO:
+    # 1. Support nested datashapes (e.g. groups)
+    # 2. Try translating unicode to ascii?  (PyTables fails here)
+    fn = uri.split('://')[1]
+    f = pd.HDFStore(fn)
+    if dshape is None:
+        if datapath:
+            return f.get_storer(datapath)
+        else:
+            return f
+    dshape = datashape.dshape(dshape)
+
+    # Already exists, return it
+    if datapath in f:
+        return f.get_storer(datapath)
+
+    # Need to create new datast.
+    # HDFStore doesn't support empty datasets, so we use a proxy object.
+    return EmptyHDFStoreDataset(f, datapath, dshape)
+
+
+@append.register((pd.io.pytables.Fixed, EmptyHDFStoreDataset), pd.DataFrame)
+def append_dataframe_to_hdfstore(store, df, **kwargs):
+    store.parent.append(store.pathname, df, append=True)
+    return store.parent.get_storer(store.pathname)
+
+
+@append.register((pd.io.pytables.Fixed, EmptyHDFStoreDataset),
+                 chunks(pd.DataFrame))
+def append_chunks_dataframe_to_hdfstore(store, c, **kwargs):
+    parent = store.parent
+    for chunk in c:
+        parent.append(store.pathname, chunk)
+    return parent.get_storer(store.pathname)
+
+
+@append.register((pd.io.pytables.Fixed, EmptyHDFStoreDataset), object)
+def append_object_to_hdfstore(store, o, **kwargs):
+    return append(store, convert(chunks(pd.DataFrame), o, **kwargs), **kwargs)

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -21,6 +21,8 @@ def discover_hdfstore(f):
 def discover_hdfstore_storer(storer):
     f = storer.parent
     n = storer.shape
+    if isinstance(n, list):
+        n = n[0]
     measure = discover(f.select(storer.pathname, start=0, stop=10)).measure
     return n * measure
 

--- a/into/backends/hdfstore.py
+++ b/into/backends/hdfstore.py
@@ -14,7 +14,17 @@ HDFDataset = (pd.io.pytables.AppendableFrameTable, pd.io.pytables.FrameFixed)
 
 @discover.register(pd.HDFStore)
 def discover_hdfstore(f):
-    return discover(dict((k.lstrip('/'), f.get_storer(k)) for k in f.keys()))
+    d = dict()
+    for key in f.keys():
+        d2 = d
+        key2 = key.lstrip('/')
+        while '/' in key2:
+            group, key2 = key2.split('/', 1)
+            if group not in d2:
+                d2[group] = dict()
+            d2 = d2[group]
+        d2[key2] = f.get_storer(key)
+    return discover(d)
 
 
 @discover.register(pd.io.pytables.Fixed)

--- a/into/backends/pytables.py
+++ b/into/backends/pytables.py
@@ -146,7 +146,7 @@ def PyTables(path, datapath, dshape=None, **kwargs):
     return tables.open_file(path, mode='a').get_node(datapath)
 
 
-@resource.register('.+\.h5')
+@resource.register('pytables://.+', priority=11)
 def resource_pytables(path, datapath, **kwargs):
     return PyTables(path, datapath, **kwargs)
 

--- a/into/backends/tests/test_h5py.py
+++ b/into/backends/tests/test_h5py.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from into.backends.h5py import append, create, resource, discover, convert
+from into.backends.h5py import (append, create, resource, discover, convert,
+        resource_h5py)
 from contextlib import contextmanager
 from into.utils import tmpfile
 from into.chunks import chunks
-from into import into, append, convert, resource, discover
+from into import into, append, convert, discover
 import datashape
 import h5py
 import numpy as np

--- a/into/backends/tests/test_hdfstore.py
+++ b/into/backends/tests/test_hdfstore.py
@@ -35,6 +35,18 @@ def test_discover():
         assert str(discover(f)) == str(discover({'data': df}))
 
 
+def test_discover():
+    with tmpfile('hdf5') as fn:
+        df.to_hdf(fn, '/a/b/data')
+        df.to_hdf(fn, '/a/b/data2')
+        df.to_hdf(fn, '/a/data')
+
+        hdf = pd.HDFStore(fn)
+
+        assert discover(hdf) == discover({'a': {'b': {'data': df, 'data2': df},
+                                                'data': df}})
+
+
 def eq(a, b):
     if isinstance(a, pd.DataFrame):
         a = into(np.ndarray, a)

--- a/into/backends/tests/test_hdfstore.py
+++ b/into/backends/tests/test_hdfstore.py
@@ -1,0 +1,104 @@
+
+from into.backends.hdfstore import discover
+from contextlib import contextmanager
+from into.utils import tmpfile
+from into.chunks import chunks
+from into import into, append, convert, resource, discover
+import datashape
+import pandas as pd
+from datetime import datetime
+import numpy as np
+import os
+
+df = pd.DataFrame([['a', 1, 10., datetime(2000, 1, 1)],
+                   ['ab', 2, 20., datetime(2000, 2, 2)],
+                   ['abc', 3, 30., datetime(2000, 3, 3)],
+                   ['abcd', 4, 40., datetime(2000, 4, 4)]],
+                   columns=['name', 'a', 'b', 'time'])
+
+
+@contextmanager
+def file(df):
+    with tmpfile('.hdf5') as fn:
+        f = pd.HDFStore(fn)
+        f.put('/data', df, format='table', append=True)
+
+        try:
+            yield fn, f, f.get_storer('/data')
+        finally:
+            f.close()
+
+
+def test_discover():
+    with file(df) as (fn, f, dset):
+        assert str(discover(dset)) == str(discover(df))
+        assert str(discover(f)) == str(discover({'data': df}))
+
+
+def eq(a, b):
+    if isinstance(a, pd.DataFrame):
+        a = into(np.ndarray, a)
+    if isinstance(b, pd.DataFrame):
+        b = into(np.ndarray, b)
+    c = a == b
+    if isinstance(c, np.ndarray):
+        c = c.all()
+    return c
+
+
+def test_chunks():
+    with file(df) as (fn, f, dset):
+        c = convert(chunks(pd.DataFrame), dset)
+        assert eq(convert(np.ndarray, c), df)
+
+
+def test_resource_no_info():
+    with tmpfile('.hdf5') as fn:
+        assert isinstance(resource('hdfstore://' + fn), pd.HDFStore)
+
+
+def test_resource_of_dataset():
+    with tmpfile('.hdf5') as fn:
+        ds = datashape.dshape('{x: int32, y: 3 * int32}')
+        r = resource('hdfstore://'+fn+'::/x', dshape=ds)
+        assert r
+
+
+def test_append():
+    with file(df) as (fn, f, dset):
+        append(dset, df)
+        append(dset, df)
+        assert discover(dset).shape[0] == len(df) * 3
+
+
+def test_into_resource():
+    with tmpfile('.hdf5') as fn:
+        d = into('hdfstore://' + fn + '::/x', df)
+        assert discover(d) == discover(df)
+        assert eq(into(pd.DataFrame, d), df)
+
+
+def test_convert_pandas():
+    with file(df) as (fn, f, dset):
+        assert eq(convert(pd.DataFrame, dset), df)
+
+
+def test_convert_chunks():
+    with file(df) as (fn, f, dset):
+        c = convert(chunks(pd.DataFrame), dset, chunksize=len(df) / 2)
+        assert len(list(c)) == 2
+        assert eq(convert(pd.DataFrame, c), df)
+
+
+def test_append_chunks():
+    with file(df) as (fn, f, dset):
+        append(dset, chunks(pd.DataFrame)([df, df]))
+
+        assert discover(dset).shape[0] == len(df) * 3
+
+
+def test_append_other():
+    with tmpfile('.hdf5') as fn:
+        x = into(np.ndarray, df)
+        dset = into('hdfstore://'+fn+'::/data', x)
+        assert discover(dset) == discover(x)

--- a/into/backends/tests/test_hdfstore.py
+++ b/into/backends/tests/test_hdfstore.py
@@ -68,7 +68,7 @@ def test_append():
     with file(df) as (fn, f, dset):
         append(dset, df)
         append(dset, df)
-        assert discover(dset).shape[0] == len(df) * 3
+        assert discover(dset).shape == (len(df) * 3,)
 
 
 def test_into_resource():
@@ -102,3 +102,11 @@ def test_append_other():
         x = into(np.ndarray, df)
         dset = into('hdfstore://'+fn+'::/data', x)
         assert discover(dset) == discover(x)
+
+
+def test_fixed_shape():
+    with tmpfile('.hdf5') as fn:
+        df.to_hdf(fn, 'foo')
+        r = resource('hdfstore://'+fn+'::/foo')
+        assert isinstance(r.shape, list)
+        assert discover(r).shape == (len(df),)

--- a/into/backends/tests/test_hdfstore.py
+++ b/into/backends/tests/test_hdfstore.py
@@ -110,3 +110,10 @@ def test_fixed_shape():
         r = resource('hdfstore://'+fn+'::/foo')
         assert isinstance(r.shape, list)
         assert discover(r).shape == (len(df),)
+
+
+def test_fixed_convert():
+    with tmpfile('.hdf5') as fn:
+        df.to_hdf(fn, 'foo')
+        r = resource('hdfstore://'+fn+'::/foo')
+        assert eq(convert(pd.DataFrame, r), df)

--- a/into/convert.py
+++ b/into/convert.py
@@ -79,6 +79,12 @@ def numpy_chunks_to_numpy(c, **kwargs):
     return np.concatenate(list(c))
 
 
+@convert.register(chunks(np.ndarray), np.ndarray, cost=0.1)
+def numpy_to_chunks_numpy(x, chunksize=2**20, **kwargs):
+    return chunks(np.ndarray)(
+            lambda: (x[i:i+chunksize] for i in range(0, x.shape[0], chunksize)))
+
+
 def ishashable(x):
     try:
         hash(x)
@@ -158,11 +164,11 @@ def numpy_record_to_tuple(rec, **kwargs):
     return rec.tolist()
 
 
-@convert.register(chunks(np.ndarray), chunks(pd.DataFrame), cost=1.0)
+@convert.register(chunks(np.ndarray), chunks(pd.DataFrame), cost=0.5)
 def chunked_pandas_to_chunked_numpy(c, **kwargs):
     return chunks(np.ndarray)(lambda: (convert(np.ndarray, chunk, **kwargs) for chunk in c))
 
-@convert.register(chunks(pd.DataFrame), chunks(np.ndarray), cost=1.0)
+@convert.register(chunks(pd.DataFrame), chunks(np.ndarray), cost=0.5)
 def chunked_numpy_to_chunked_pandas(c, **kwargs):
     return chunks(pd.DataFrame)(lambda: (convert(pd.DataFrame, chunk, **kwargs) for chunk in c))
 

--- a/into/convert.py
+++ b/into/convert.py
@@ -79,11 +79,21 @@ def numpy_chunks_to_numpy(c, **kwargs):
     return np.concatenate(list(c))
 
 
-@convert.register(chunks(np.ndarray), np.ndarray, cost=0.1)
+@convert.register(chunks(np.ndarray), np.ndarray, cost=0.5)
 def numpy_to_chunks_numpy(x, chunksize=2**20, **kwargs):
     return chunks(np.ndarray)(
             lambda: (x[i:i+chunksize] for i in range(0, x.shape[0], chunksize)))
 
+
+@convert.register(pd.DataFrame, chunks(pd.DataFrame), cost=1.0)
+def chunks_dataframe_to_dataframe(c, **kwargs):
+    return pd.concat(list(c), axis=0)
+
+
+@convert.register(chunks(pd.DataFrame), pd.DataFrame, cost=0.5)
+def dataframe_to_chunks_dataframe(x, chunksize=2**20, **kwargs):
+    return chunks(pd.DataFrame)(
+            lambda: (x.iloc[i:i+chunksize] for i in range(0, x.shape[0], chunksize)))
 
 def ishashable(x):
     try:

--- a/into/tests/test_convert.py
+++ b/into/tests/test_convert.py
@@ -1,4 +1,5 @@
-from into.convert import convert, list_to_numpy, iterator_to_numpy_chunks
+from into.convert import (convert, list_to_numpy, iterator_to_numpy_chunks,
+        numpy_to_chunks_numpy)
 from into.chunks import chunks
 from datashape import discover
 from toolz import first
@@ -138,3 +139,11 @@ def test_numpy_to_list_preserves_ns_datetimes():
     x = np.array([(0, 0)], dtype=[('a', 'M8[ns]'), ('b', 'i4')])
 
     assert convert(list, x) == [(datetime.datetime(1970, 1, 1, 0, 0), 0)]
+
+
+def test_numpy_to_chunks_numpy():
+    x = np.arange(100)
+    c = numpy_to_chunks_numpy(x, chunksize=10)
+    assert isinstance(c, chunks(np.ndarray))
+    assert len(list(c)) == 10
+    assert eq(list(c)[0], x[:10])

--- a/into/tests/test_convert.py
+++ b/into/tests/test_convert.py
@@ -1,5 +1,6 @@
 from into.convert import (convert, list_to_numpy, iterator_to_numpy_chunks,
-        numpy_to_chunks_numpy)
+        numpy_to_chunks_numpy, dataframe_to_chunks_dataframe,
+        chunks_dataframe_to_dataframe)
 from into.chunks import chunks
 from datashape import discover
 from toolz import first
@@ -147,3 +148,14 @@ def test_numpy_to_chunks_numpy():
     assert isinstance(c, chunks(np.ndarray))
     assert len(list(c)) == 10
     assert eq(list(c)[0], x[:10])
+
+
+def test_pandas_and_chunks_pandas():
+    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [1., 2., 3., 4.]})
+
+    c = dataframe_to_chunks_dataframe(df, chunksize=2)
+    assert isinstance(c, chunks(pd.DataFrame))
+    assert len(list(c)) == 2
+
+    df2 = chunks_dataframe_to_dataframe(c)
+    assert str(df2) == str(df)


### PR DESCRIPTION
This is a work in progress.  It's an alternative implementation to #8 that tries to be just about supporting `HDFStore` in isolation.

Some issues came up

1.  HDFStore doesn't support empty datasets, this causes a bit of a hacky solution here.  It'd be nice if that was supported upstream
2.  I don't yet support groups, just flat HDF5 files
3.  PyTables doesn't like unicode and datashape usually assumes unicode by default.  This mismatch makes doing work rather finicky.  You have to specify kwarg stuff fairly often.  It might make sense to default to replace all instances of `string` with `string["A"]`.
4.  I have yet to really give it the run-around on lots of datasets
5.  Doesn't address any of the side concerns brought up in #8

On the plus side, it is short and snappy.  

Questions:

1. Is `HDFStore` intended to interact with datasets that don't fit the DataFrame model?  Should I bother to try to generalize or no?  
2.  How does `HDFStore` handle strings?  Only Python objects or is there some way to specify fixed-length?
3.  Is it possible to get particular chunks out of a `pd.io.pytables.FixedFrame` object?  I've been using the `HDFStore.select` method and none of the `chunksize`, `start/stop` kwargs work for this.

TODO (maybe future work):

- [ ] Raise informative errors if a file in `resource('.hdf5')` if a user tries to use a datetime datashape.  Suggest use of `hdfstore://` protocol
- [ ] Inspect metadata to see if we can identify HDFStore formatted hdf5 files automatically
