### PR TITLE
append(sql, Iterator) uses names from dshape

### DIFF
--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -211,7 +211,7 @@ def sql_to_iterator(t, **kwargs):
 
 
 @append.register(sa.Table, Iterator)
-def append_iterator_to_table(t, rows, **kwargs):
+def append_iterator_to_table(t, rows, dshape=None, **kwargs):
     assert not isinstance(t, type)
     rows = iter(rows)
 
@@ -223,7 +223,10 @@ def append_iterator_to_table(t, rows, **kwargs):
         return
     rows = chain([row], rows)
     if isinstance(row, (tuple, list)):
-        names = discover(t).measure.names
+        if dshape:
+            names = dshape.measure.names
+        else:
+            names = discover(t).measure.names
         rows = (dict(zip(names, row)) for row in rows)
 
     engine = t.bind

--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -223,8 +223,14 @@ def append_iterator_to_table(t, rows, dshape=None, **kwargs):
         return
     rows = chain([row], rows)
     if isinstance(row, (tuple, list)):
-        if dshape:
+        if dshape and isinstance(dshape.measure, datashape.Record):
             names = dshape.measure.names
+            if not set(names) == set(discover(t).measure.names):
+                raise ValueError("Column names of incoming data don't match "
+                "column names of existing SQL table\n"
+                "Names in SQL table: %s\n"
+                "Names from incoming data: %s\n" %
+                (discover(t).measure.names, names))
         else:
             names = discover(t).measure.names
         rows = (dict(zip(names, row)) for row in rows)

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -5,7 +5,7 @@ from datashape import discover, dshape
 import datashape
 from into.backends.sql import (dshape_to_table, create_from_datashape,
         dshape_to_alchemy)
-from into.utils import tmpfile
+from into.utils import tmpfile, raises
 from into import convert, append, create, resource, discover
 
 
@@ -172,6 +172,12 @@ def test_sql_field_names_disagree_on_order():
     r = resource('sqlite:///:memory:::tb', dshape=dshape('{x: int, y: int}'))
     append(r, [(1, 2), (10, 20)], dshape=dshape('{y: int, x: int}'))
     assert convert(set, r) == set([(2, 1), (20, 10)])
+
+
+def test_sql_field_names_disagree_on_names():
+    r = resource('sqlite:///:memory:::tb', dshape=dshape('{x: int, y: int}'))
+    assert raises(Exception, lambda:
+            append(r, [(1, 2), (10, 20)], dshape=dshape('{x: int, z: int}')))
 
 
 def test_resource_on_dialects():

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -160,13 +160,18 @@ def test_into_table_iterator():
 
     assert convert(list, t) == data
 
-
     t2 = dshape_to_table('points2', '{x: int, y: int}', metadata=metadata)
     t2.create()
     data2 = [{'x': 1, 'y': 1}, {'x': 2, 'y': 4}, {'x': 3, 'y': 9}]
     append(t2, data2)
 
     assert convert(list, t2) == data
+
+
+def test_sql_field_names_disagree_on_order():
+    r = resource('sqlite:///:memory:::tb', dshape=dshape('{x: int, y: int}'))
+    append(r, [(1, 2), (10, 20)], dshape=dshape('{y: int, x: int}'))
+    assert convert(set, r) == set([(2, 1), (20, 10)])
 
 
 def test_resource_on_dialects():


### PR DESCRIPTION
Previously we looked to the SQL table to tell us what field names to use.  Now we consider an incoming dshape from the source.

```Python
In [1]: from into import resource, append, convert, dshape

In [2]: r = resource('sqlite:///:memory:::tb', dshape=dshape('{x: int, y: int}'))
In [4]: append(r, [(1, 2), (10, 20)], dshape=dshape('{y: int, x: int}'))  # Note reversed order

In [5]: convert(set, r)  # Note correctly reversed order
Out[5]: {(2, 1), (20, 10)}

In [6]: r = resource('sqlite:///:memory:::tb2', dshape=dshape('{x: int, y: int}'))
In [7]: append(r, [(1, 2), (10, 20)], dshape=dshape('{x: int, z: int}'))  # Note bad column name
ValueError: Column names of incoming data don't match column names of existing SQL table
Names in SQL table: ['x', 'y']
Names from incoming data: ['x', 'z']
```