### PR TITLE
ndarray <-> recarray conversions

### DIFF
--- a/into/convert.py
+++ b/into/convert.py
@@ -14,14 +14,6 @@ from .numpy_dtype import dshape_to_numpy
 convert = NetworkDispatcher('convert')
 
 
-def identity(x, **kwargs):
-    """
-
-    >>> identity('anything')
-    'anything'
-    """
-    return x
-
 @convert.register(np.ndarray, pd.DataFrame, cost=0.2)
 def dataframe_to_numpy(df, dshape=None, **kwargs):
     dtype = dshape_to_numpy(dshape)
@@ -51,8 +43,14 @@ def DataFrame_to_Series(x, **kwargs):
 def series_to_dataframe(x, **kwargs):
     return x.to_frame()
 
-convert.register(np.recarray, np.ndarray, cost=0.0)(identity)
-convert.register(np.ndarray, np.recarray, cost=0.0)(identity)
+
+@convert.register(np.recarray, np.ndarray, cost=0.0)
+def ndarray_to_recarray(x, **kwargs):
+    return x.view(np.recarray)
+
+@convert.register(np.ndarray, np.recarray, cost=0.0)
+def recarray_to_ndarray(x, **kwargs):
+    return x.view(np.ndarray)
 
 
 higher_precision_freqs = frozenset(('ns', 'ps', 'fs', 'as'))

--- a/into/tests/test_convert.py
+++ b/into/tests/test_convert.py
@@ -181,3 +181,14 @@ def test_pandas_and_chunks_pandas():
 
     df2 = chunks_dataframe_to_dataframe(c)
     assert str(df2) == str(df)
+
+
+def test_recarray():
+    data = np.array([(1, 1.), (2, 2.)], dtype=[('a', 'i4'), ('b', 'f4')])
+    result = convert(np.recarray, data)
+    assert isinstance(result, np.recarray)
+    assert eq(result.a, data['a'])
+
+    result2 = convert(np.ndarray, data)
+    assert not isinstance(result2, np.recarray)
+    assert eq(result2, data)


### PR DESCRIPTION
Support `np.recarray` conversions.  Previously we silently failed here.

```Python
In [1]: from into import into, np
In [2]: x = np.array([(1, 1.), (2, 2.)], dtype=[('a', 'i4'), ('b', 'f4')])

In [3]: r = into(np.recarray, x)
In [4]: type(r)
Out[4]: numpy.core.records.recarray

In [5]: r.a
Out[5]: array([1, 2], dtype=int32)
```

Fixes #24 