### PR TITLE
JSON and JSONLines backend targets

### DIFF
--- a/into/__init__.py
+++ b/into/__init__.py
@@ -51,6 +51,10 @@ try:
 except:
     pass
 try:
+     from .backends.json import JSON, JSONLines
+except:
+    pass
+try:
      from .backends import sql_csv
 except:
     pass

--- a/into/backends/json.py
+++ b/into/backends/json.py
@@ -148,9 +148,9 @@ def resource_json_ambiguous(path, **kwargs):
     # File doesn't exist, is the dshape variable length?
     dshape = kwargs.get('dshape', None)
     if dshape and dshape[0] == var:
-        return resource_jsonlines(path, dshape=dshape, **kwargs)
+        return resource_jsonlines(path, **kwargs)
     else:
-        return resource_json(path, dshape=dshape, **kwargs)
+        return resource_json(path, **kwargs)
 
 
 ooc_types.add(JSONLines)

--- a/into/backends/json.py
+++ b/into/backends/json.py
@@ -1,0 +1,155 @@
+from __future__ import absolute_import, division, print_function
+
+import json
+from toolz.curried import map, take, pipe, pluck, get
+from collections import Iterator
+import os
+
+from datashape import discover, var, dshape, Record
+from ..append import append
+from ..convert import convert, ooc_types
+from ..resource import resource
+from ..chunks import chunks
+from ..numpy_dtype import dshape_to_pandas
+from .pandas import coerce_datetimes
+
+
+class JSON(object):
+    """ Proxy for a JSON file
+
+    Parameters
+    ----------
+
+    path : str
+        Path to file on disk
+
+    See Also
+    --------
+
+    JSONLines - Line-delimited JSON
+    """
+    def __init__(self, path):
+        self.path = path
+
+
+class JSONLines(object):
+    """ Proxy for a line-delimited JSON file
+
+    Each line in the file is a valid JSON entry
+
+    Parameters
+    ----------
+
+    path : str
+        Path to file on disk
+
+    See Also
+    --------
+
+    JSON - Not-line-delimited JSON
+    """
+    def __init__(self, path):
+        self.path = path
+
+
+@discover.register(JSON)
+def discover_json(j, **kwargs):
+    with open(j.path) as f:
+        data = json.load(f)
+    return discover(data)
+
+
+@discover.register(JSONLines)
+def discover_json(j, n=10, **kwargs):
+    with open(j.path) as f:
+        data = pipe(f, map(json.loads), take(n), list)
+    if len(data) < n:
+        return discover(data)
+    else:
+        return datashape.var * discover(data).subshape[0]
+
+
+@convert.register(list, JSON)
+def json_to_list(j, dshape=None, **kwargs):
+    with open(j.path) as f:
+        data = json.load(f)
+    return data
+
+
+@convert.register(Iterator, JSONLines)
+def json_lines_to_iterator(j, **kwargs):
+    f = open(j.path)
+    return map(json.loads, f)
+
+
+@append.register(JSONLines, object)
+def object_to_jsonlines(j, o, **kwargs):
+    return append(j, convert(Iterator, o, **kwargs), **kwargs)
+
+
+@append.register(JSONLines, Iterator)
+def iterator_to_json_lines(j, seq, **kwargs):
+    with open(j.path, 'a') as f:
+        for item in seq:
+            json.dump(item, f)
+            f.write('\n')
+    return j
+
+
+@append.register(JSON, list)
+def list_to_json(j, seq, **kwargs):
+    if os.path.exists(j.path):
+        with open(j.path) as f:
+            assert not json.load(f)  # assert empty
+
+    with open(j.path, 'w') as f:
+        json.dump(seq, f)
+
+
+@append.register(JSON, object)
+def object_to_json(j, o, **kwargs):
+    return append(j, convert(list, o, **kwargs), **kwargs)
+
+
+@resource.register('json://.*\.json', priority=11)
+def resource_json(path, **kwargs):
+    if 'json://' in path:
+        path = path[len('json://'):]
+    return JSON(path)
+
+
+@resource.register('jsonlines://.*\.json', priority=11)
+def resource_jsonlines(path, **kwargs):
+    if 'jsonlines://' in path:
+        path = path[len('jsonlines://'):]
+    return JSONLines(path)
+
+
+@resource.register('.*\.json')
+def resource_json_ambiguous(path, **kwargs):
+    """ Try to guess if this file is line-delimited or not """
+    if os.path.exists(path):
+        with open(path) as f:
+            one = next(f)
+            try:
+                two = next(f)
+            except StopIteration:  # only one line
+                return resource_json(path, **kwargs)
+            try:
+                json.loads(one)
+                return resource_jsonlines(path, **kwargs)
+            except:
+                return resource_json(path, **kwargs)
+
+    # File doesn't exist, is the dshape variable length?
+    dshape = kwargs.get('dshape', None)
+    if not dshape:
+        raise ValueError("Don't know if you intend line-delimited or no."
+                "Please add protocol json:// or jsonlines:// as appropriate")
+    if dshape[0] == var:
+        return resource_jsonlines(path, dshape=dshape, **kwargs)
+    else:
+        return resource_json(path, dshape=dshape, **kwargs)
+
+
+ooc_types.add(JSONLines)

--- a/into/backends/json.py
+++ b/into/backends/json.py
@@ -118,6 +118,7 @@ def resource_json(path, **kwargs):
     return JSON(path)
 
 
+@resource.register('.*\.jsonlines', priority=11)
 @resource.register('jsonlines://.*\.json', priority=11)
 def resource_jsonlines(path, **kwargs):
     if 'jsonlines://' in path:

--- a/into/backends/json.py
+++ b/into/backends/json.py
@@ -129,24 +129,24 @@ def resource_jsonlines(path, **kwargs):
 def resource_json_ambiguous(path, **kwargs):
     """ Try to guess if this file is line-delimited or not """
     if os.path.exists(path):
-        with open(path) as f:
-            one = next(f)
-            try:
-                two = next(f)
-            except StopIteration:  # only one line
-                return resource_json(path, **kwargs)
-            try:
-                json.loads(one)
-                return resource_jsonlines(path, **kwargs)
-            except:
-                return resource_json(path, **kwargs)
+        f = open(path)
+        one = next(f)
+        try:
+            two = next(f)
+        except StopIteration:  # only one line
+            f.close()
+            return resource_json(path, **kwargs)
+        try:
+            json.loads(one)
+            f.close()
+            return resource_jsonlines(path, **kwargs)
+        except:
+            f.close()
+            return resource_json(path, **kwargs)
 
     # File doesn't exist, is the dshape variable length?
     dshape = kwargs.get('dshape', None)
-    if not dshape:
-        raise ValueError("Don't know if you intend line-delimited or no."
-                "Please add protocol json:// or jsonlines:// as appropriate")
-    if dshape[0] == var:
+    if dshape and dshape[0] == var:
         return resource_jsonlines(path, dshape=dshape, **kwargs)
     else:
         return resource_json(path, dshape=dshape, **kwargs)

--- a/into/backends/tests/test_json.py
+++ b/into/backends/tests/test_json.py
@@ -1,0 +1,86 @@
+from into.backends.json import *
+from into.utils import tmpfile
+from contextlib import contextmanager
+from datashape import dshape
+import json
+
+@contextmanager
+def json_file(data):
+    with tmpfile('.json') as fn:
+        with open(fn, 'w') as f:
+            json.dump(data, f)
+
+        yield fn
+
+@contextmanager
+def jsonlines_file(data):
+    with tmpfile('.json') as fn:
+        with open(fn, 'w') as f:
+            for item in data:
+                json.dump(item, f)
+                f.write('\n')
+
+        yield fn
+
+
+dat = [{'name': 'Alice', 'amount': 100},
+       {'name': 'Bob', 'amount': 200}]
+
+def test_discover_json():
+    with json_file(dat) as fn:
+        j = JSON(fn)
+        assert discover(j) == discover(dat)
+
+def test_discover_jsonlines():
+    with jsonlines_file(dat) as fn:
+        j = JSONLines(fn)
+        assert discover(j) == discover(dat)
+
+
+def test_resource():
+    assert isinstance(resource('jsonlines://foo.json'), JSONLines)
+    assert isinstance(resource('json://foo.json'), JSON)
+
+    assert isinstance(resource('foo.json', dshape=dshape('var * {a: int}')),
+                      JSONLines)
+
+def test_resource_guessing():
+    with json_file(dat) as fn:
+        assert isinstance(resource(fn), JSON)
+
+    with jsonlines_file(dat) as fn:
+        assert isinstance(resource(fn), JSONLines)
+
+
+def test_append_jsonlines():
+    with tmpfile('json') as fn:
+        j = JSONLines(fn)
+        append(j, dat)
+        with open(j.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+        assert 'Alice' in lines[0]
+        assert 'Bob' in lines[1]
+
+
+def test_append_json():
+    with tmpfile('json') as fn:
+        j = JSON(fn)
+        append(j, dat)
+        with open(j.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        assert 'Alice' in lines[0]
+        assert 'Bob' in lines[0]
+
+
+def test_convert_json_list():
+    with json_file(dat) as fn:
+        j = JSON(fn)
+        assert convert(list, j) == dat
+
+
+def test_convert_jsonlines():
+    with jsonlines_file(dat) as fn:
+        j = JSONLines(fn)
+        assert convert(list, j) == dat

--- a/into/backends/tests/test_json.py
+++ b/into/backends/tests/test_json.py
@@ -1,14 +1,16 @@
 from into.backends.json import *
 from into.utils import tmpfile
+from into import into
 from contextlib import contextmanager
 from datashape import dshape
+import datetime
 import json
 
 @contextmanager
 def json_file(data):
     with tmpfile('.json') as fn:
         with open(fn, 'w') as f:
-            json.dump(data, f)
+            json.dump(data, f, default=json_dumps)
 
         yield fn
 
@@ -17,7 +19,7 @@ def jsonlines_file(data):
     with tmpfile('.json') as fn:
         with open(fn, 'w') as f:
             for item in data:
-                json.dump(item, f)
+                json.dump(item, f, default=json_dumps)
                 f.write('\n')
 
         yield fn
@@ -37,11 +39,19 @@ def test_discover_jsonlines():
         assert discover(j) == discover(dat)
 
 
+def test_discover_json_only_includes_datetimes_not_dates():
+    data = [{'name': 'Alice', 'dt': datetime.date(2002, 2, 2)},
+            {'name': 'Bob',   'dt': datetime.date(2000, 1, 1)}]
+    with json_file(data) as fn:
+        j = JSON(fn)
+        assert discover(j) == dshape('2 * {dt: datetime, name: string }')
+
+
 def test_resource():
     assert isinstance(resource('jsonlines://foo.json'), JSONLines)
     assert isinstance(resource('json://foo.json'), JSON)
 
-    assert isinstance(resource('foo.json', dshape=dshape('var * {a: int}')),
+    assert isinstance(resource('foo.json', expected_dshape=dshape('var * {a: int}')),
                       JSONLines)
 
 def test_resource_guessing():
@@ -101,3 +111,22 @@ def test_tuples_to_json():
         append(j, [(1, 2), (10, 20)], dshape=ds)
         with open(fn) as f:
             assert '"a": 1' in f.read()
+
+
+def test_datetimes():
+    from into import into
+    import numpy as np
+    data = [{'a': 1, 'dt': datetime.datetime(2001, 1, 1)},
+            {'a': 2, 'dt': datetime.datetime(2002, 2, 2)}]
+    with tmpfile('json') as fn:
+        j = JSONLines(fn)
+        append(j, data)
+
+        assert str(into(np.ndarray, j)) == str(into(np.ndarray, data))
+
+
+def test_json_encoder():
+    result = json.dumps([1, datetime.datetime(2000, 1, 1, 12, 30, 0)],
+                       default=json_dumps)
+    assert result == '[1, "2000-01-01T12:30:00Z"]'
+    assert json.loads(result) == [1, "2000-01-01T12:30:00Z"]

--- a/into/backends/tests/test_json.py
+++ b/into/backends/tests/test_json.py
@@ -84,3 +84,20 @@ def test_convert_jsonlines():
     with jsonlines_file(dat) as fn:
         j = JSONLines(fn)
         assert convert(list, j) == dat
+
+
+def test_tuples_to_json():
+    ds = dshape('var * {a: int, b: int}')
+    with tmpfile('json') as fn:
+        j = JSON(fn)
+
+        append(j, [(1, 2), (10, 20)], dshape=ds)
+        with open(fn) as f:
+            assert '"a": 1' in f.read()
+
+    with tmpfile('json') as fn:
+        j = JSONLines(fn)
+
+        append(j, [(1, 2), (10, 20)], dshape=ds)
+        with open(fn) as f:
+            assert '"a": 1' in f.read()

--- a/into/convert.py
+++ b/into/convert.py
@@ -9,6 +9,7 @@ import datashape
 from .core import NetworkDispatcher, ooc_types
 from .chunks import chunks, Chunks
 from .numpy_dtype import dshape_to_numpy
+from .utils import records_to_tuples
 
 
 convert = NetworkDispatcher('convert')
@@ -135,8 +136,22 @@ def iterable_to_tuple(x, **kwargs):
     return tuple(x)
 
 
+def element_of(seq):
+    """
+
+    >>> element_of([1, 2, 3])
+    1
+    >>> element_of([[1, 2], [3, 4]])
+    1
+    """
+    while isinstance(seq, list) and seq:
+        seq = seq[0]
+    return seq
+
 @convert.register(np.ndarray, list, cost=10.0)
 def list_to_numpy(seq, dshape=None, **kwargs):
+    if isinstance(element_of(seq), dict):
+        seq = list(records_to_tuples(dshape, seq))
     if (seq and isinstance(seq[0], Iterable)
             and not ishashable(seq[0])
             and not isscalar(dshape)):

--- a/into/tests/test_convert.py
+++ b/into/tests/test_convert.py
@@ -97,6 +97,14 @@ def test_list_to_numpy_on_tuples():
     assert convert(list, x) == [('a', 1), ('b', 2), ('c', 3)]
 
 
+def test_list_to_numpy_on_dicts():
+    data = [{'name': 'Alice', 'amount': 100},
+            {'name': 'Bob', 'amount': 200}]
+    ds = datashape.dshape('var * {name: string[5, "A"], amount: int}')
+    x = list_to_numpy(data, dshape=ds)
+    assert convert(list, x) == [('Alice', 100), ('Bob', 200)]
+
+
 def test_chunks_numpy_pandas():
     x = np.array([('Alice', 100), ('Bob', 200)],
                  dtype=[('name', 'S7'), ('amount', 'i4')])

--- a/into/tests/test_convert.py
+++ b/into/tests/test_convert.py
@@ -100,7 +100,7 @@ def test_list_to_numpy_on_tuples():
 def test_list_to_numpy_on_dicts():
     data = [{'name': 'Alice', 'amount': 100},
             {'name': 'Bob', 'amount': 200}]
-    ds = datashape.dshape('var * {name: string[5, "A"], amount: int}')
+    ds = datashape.dshape('var * {name: string[5], amount: int}')
     x = list_to_numpy(data, dshape=ds)
     assert convert(list, x) == [('Alice', 100), ('Bob', 200)]
 

--- a/into/utils.py
+++ b/into/utils.py
@@ -176,10 +176,10 @@ def tuples_to_records(ds, data):
     Examples
     --------
     >>> seq = [(1, 10), (2, 20)]
-    >>> list(tuples_to_records('var * {a: int, b: int}', seq))
+    >>> list(tuples_to_records('var * {a: int, b: int}', seq))  # doctest: +SKIP
     [{'a': 1, 'b': 10}, {'a': 2, 'b': 20}]
 
-    >>> tuples_to_records('{a: int, b: int}', seq[0])  # single elements
+    >>> tuples_to_records('{a: int, b: int}', seq[0])  # doctest: +SKIP
     {'a': 1, 'b': 10}
 
     >>> tuples_to_records('var * int', [1, 2, 3])  # pass through on non-records

--- a/into/utils.py
+++ b/into/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from datashape import dshape, Record
+from toolz import pluck, get
 from contextlib import contextmanager
 import inspect
 import datetime
@@ -133,4 +135,70 @@ def assert_allclose(lhs, rhs):
             if isinstance(right, datetime.datetime):
                 right = normalize_to_date(right)
             assert left == right
+
+
+
+def records_to_tuples(ds, data):
+    """ Transform records into tuples
+
+    Examples
+    --------
+    >>> seq = [{'a': 1, 'b': 10}, {'a': 2, 'b': 20}]
+    >>> list(records_to_tuples('var * {a: int, b: int}', seq))
+    [(1, 10), (2, 20)]
+
+    >>> records_to_tuples('{a: int, b: int}', seq[0])  # single elements
+    (1, 10)
+
+    >>> records_to_tuples('var * int', [1, 2, 3])  # pass through on non-records
+    [1, 2, 3]
+
+    See Also
+    --------
+
+    tuples_to_records
+    """
+    if isinstance(ds, (str, unicode)):
+        ds = dshape(ds)
+    if isinstance(ds.measure, Record) and len(ds.shape) == 1:
+        return pluck(ds.measure.names, data)
+    if isinstance(ds.measure, Record) and len(ds.shape) == 0:
+        return get(ds.measure.names, data)
+    if not isinstance(ds.measure, Record):
+        return data
+    raise NotImplementedError()
+
+
+def tuples_to_records(ds, data):
+    """ Transform tuples into records
+
+    Examples
+    --------
+    >>> seq = [(1, 10), (2, 20)]
+    >>> list(tuples_to_records('var * {a: int, b: int}', seq))
+    [{'a': 1, 'b': 10}, {'a': 2, 'b': 20}]
+
+    >>> tuples_to_records('{a: int, b: int}', seq[0])  # single elements
+    {'a': 1, 'b': 10}
+
+    >>> tuples_to_records('var * int', [1, 2, 3])  # pass through on non-records
+    [1, 2, 3]
+
+    See Also
+    --------
+
+    records_to_tuples
+    """
+    if isinstance(ds, (str, unicode)):
+        ds = dshape(ds)
+    if isinstance(ds.measure, Record) and len(ds.shape) == 1:
+        names = ds.measure.names
+        return (dict(zip(names, tup)) for tup in data)
+    if isinstance(ds.measure, Record) and len(ds.shape) == 0:
+        names = ds.measure.names
+        return dict(zip(names, data))
+    if not isinstance(ds.measure, Record):
+        return data
+    raise NotImplementedError()
+
 

--- a/into/utils.py
+++ b/into/utils.py
@@ -8,6 +8,7 @@ import datetime
 import tempfile
 import os
 import numpy as np
+from .compatibility import unicode
 
 
 def raises(err, lamda):


### PR DESCRIPTION
Adds tiny proxy classes for `JSON` and `JSONLines` (line delimited JSON) and hooks to and from `list` and `Iterator` respectively.  Also provides functions to support `list -> np.ndarray` with list of dictionaries.

Notably this lacks any support for `gzip`.  I wouldn't mind putting that off for a separate PR.

```Python
In [1]: !cat foo.json
[{"name": "Alice", "amount": 100},
 {"name": "Bob", "amount": 200}]

In [2]: !cat foo2.json
{"name": "Alice", "amount": 100}
{"name": "Bob", "amount": 200}

In [3]: from into import *

In [4]: into(np.ndarray, 'foo.json')
Out[4]: 
array([(100, u'Alice'), (200, u'Bob')], 
      dtype=[('amount', '<i8'), ('name', 'O')])

In [5]: into(np.ndarray, 'foo2.json')
Out[5]: 
array([(100, u'Alice'), (200, u'Bob')], 
      dtype=[('amount', '<i8'), ('name', 'O')])

In [6]: into('foo2.json', 'foo2.json')
Out[6]: <into.backends.json.JSONLines at 0x7fc7fd6bfd90>

In [7]: !cat foo2.json
{"name": "Alice", "amount": 100}
{"name": "Bob", "amount": 200}
{"amount": 100, "name": "Alice"}
{"amount": 200, "name": "Bob"}
```