### PR TITLE
HDFS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: False
+
 language: python
 python:
     - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,16 @@ install:
   # For bcolz
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
 
+# Before_script section stolen from fabric
+# See license https://github.com/fabric/fabric/blob/master/LICENSE
+before_script:
+ # Allow us to SSH passwordless to localhost
+ - ssh-keygen -f ~/.ssh/id_rsa -N ""
+ - cp ~/.ssh/{id_rsa.pub,authorized_keys}
+ # Creation of an SSH agent for testing forwarding
+ - eval $(ssh-agent)
+ - ssh-add
+
 script:
     - py.test --doctest-modules into
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate test-environment
 
   # Install PyMongo
-  - pip install pymongo pymysql paramiko sas7bdat psycopg2 pywebhdfs
+  - pip install pymongo pymysql paramiko sas7bdat psycopg2
 
   # Install DataShape
   - pip install --upgrade git+http://github.com/ContinuumIO/datashape

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate test-environment
 
   # Install PyMongo
-  - pip install pymongo pymysql paramiko sas7bdat psycopg2
+  - pip install pymongo pymysql paramiko sas7bdat psycopg2 pywebhdfs
 
   # Install DataShape
   - pip install --upgrade git+http://github.com/ContinuumIO/datashape

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,19 +26,10 @@ install:
   - source activate test-environment
 
   # Install PyMongo
-  - pip install pymongo
-
-  # Install MySQL py2.y/3.x
-  - pip install pymysql
+  - pip install pymongo pymysql paramiko sas7bdat psycopg2
 
   # Install DataShape
   - pip install --upgrade git+http://github.com/ContinuumIO/datashape
-
-  # Install sas7bdat
-  - pip install sas7bdat
-
-  # install psycopg2 for postgres testing
-  - pip install psycopg2
 
   # For bcolz
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi

--- a/into/__init__.py
+++ b/into/__init__.py
@@ -63,6 +63,10 @@ try:
 except:
     pass
 try:
+     from .backends.ssh import SSH
+except:
+    pass
+try:
      from .backends import sql_csv
 except:
     pass

--- a/into/__init__.py
+++ b/into/__init__.py
@@ -7,6 +7,7 @@ halt_ordering() # Turn off multipledispatch ordering
 from .convert import convert
 from .append import append
 from .resource import resource
+from .directory import Directory
 from .into import into
 from .drop import drop
 from .chunks import chunks, Chunks

--- a/into/__init__.py
+++ b/into/__init__.py
@@ -59,6 +59,10 @@ try:
 except:
     pass
 try:
+     from .backends.hdfs import HDFS
+except:
+    pass
+try:
      from .backends import sql_csv
 except:
     pass

--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -246,36 +246,4 @@ def drop(c):
     os.unlink(c.path)
 
 
-"""
-@append.register(CSV, Iterator)
-def append_iterator_to_csv(c, seq, dshape=None, **kwargs):
-    f = open(c.path, mode='a')
-
-    # TODO: handle dict case
-    writer = csv.writer(f, **c.dialect)
-    writer.writerows(seq)
-    return c
-
-
-try:
-    from dynd import nd
-    @convert.register(Iterator, CSV)
-    def csv_to_iterator(c, chunksize=1024, dshape=None, **kwargs):
-        f = open(c.path)
-        reader = csv.reader(f, **c.dialect)
-        if c.header:
-            next(reader)
-
-        # Launder types through DyND
-        seq = pipe(reader, partition_all(chunksize),
-                           map(partial(nd.array, type=str(dshape.measure))),
-                           map(partial(nd.as_py, tuple=True)),
-                           concat)
-
-        return reader
-except ImportError:
-    pass
-"""
-
-
 ooc_types.add(CSV)

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -8,7 +8,6 @@ import datashape
 import sqlalchemy as sa
 from datashape import discover, dshape
 from datashape import coretypes as ct
-from pywebhdfs.webhdfs import PyWebHdfsClient
 from collections import namedtuple
 from contextlib import contextmanager
 from .ssh import SSH, _SSH
@@ -17,7 +16,12 @@ from ..utils import tmpfile, sample
 from ..append import append
 from ..resource import resource
 from ..directory import _Directory, Directory
+from ..compatibility import unicode
 
+try:
+    from pywebhdfs.webhdfs import PyWebHdfsClient
+except ImportError:
+    pass
 
 class _HDFS(object):
     """ Parent class for data on Hadoop File System

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -5,19 +5,18 @@ from functools import wraps
 
 from .csv import CSV
 import datashape
+import sqlalchemy as sa
 from datashape import discover
 from datashape import coretypes as ct
 from pywebhdfs.webhdfs import PyWebHdfsClient
 from collections import namedtuple
 from contextlib import contextmanager
 from .sql import metadata_of_engine, sa
-from ..utils import tmpfile
+from ..utils import tmpfile, sample
 from ..append import append
 from ..resource import resource
 from ..directory import _Directory, Directory
 
-from multipledispatch import Dispatcher
-sample = Dispatcher('sample')
 
 class _HDFS(object):
     """ Parent class for data on Hadoop File System
@@ -88,6 +87,43 @@ def discover_hdfs_directory(data, length=10000, **kwargs):
         result = discover(o)
     return result
 
+"""
+Hive Tables
+===========
+
+Hive acts a bit differently from other databases that we interact with through
+SQL.  As a result we need to special case a lot of code.
+
+Foremost, a database is just a directory on HDFS holding something like a CSV
+file (or Avro, Parquet, etc..)  As a result when we construct a Table we
+actually have to know a lot about our CSV files (e.g. delimiter.)
+
+This breaks the current into model a bit because we usually create things with
+`resource` and then `append` on to them.  Here we need to know both at the
+same time.  Enter a convenient hack, a token for a proxy table
+"""
+
+TableProxy = namedtuple('TableProxy', 'engine,name')
+
+"""
+resource('hive://...::tablename') now gives us one of these.  The
+subsequent call to `append` does the actual creation.
+
+We're looking for better solutions.  For the moment, this works.
+"""
+
+@resource.register('hive://.+::.+', priority=16)
+def resource_hive_table(uri, **kwargs):
+    uri, table = uri.split('::')
+    engine = resource(uri, **kwargs)
+    metadata = metadata_of_engine(engine)
+    if table in metadata.tables:
+        return metadata.tables[table]
+    metadata.reflect(engine, views=False)
+    if table in metadata.tables:
+        return metadata.tables[table]
+    return TableProxy(engine, table)
+
 
 hive_types = {
         ct.int8: 'TINYINT',
@@ -128,15 +164,26 @@ def dshape_to_hive(ds):
     raise NotImplementedError("No Hive dtype known for %s" % ds)
 
 
+
+"""
+Load Data in HDFS into Hive
+===========================
+
+We push types like HDFS(CSV) and HDFS(Directory(CSV)) into Hive tables.  This
+requires that we bring a bit of the CSV file locally, inspect it (sniff for csv
+dialect), generate the appropriate CREATE EXTERNAL TABLE command, and then
+execute.
+"""
+
 import csv
 sniffer = csv.Sniffer()
 
+def create_hive_from_hdfs_directory_of_csvs(tbl, data, dshape=None, **kwargs):
+    """
+    Generate string to create Hive table
 
-from ..regex import RegexDispatcher
-create_command = RegexDispatcher('create_command')
-
-@create_command.register('hive')
-def create_hive(dialect, tbl, data, dshape=None, **kwargs):
+    Most of the logic is here.  Also easy to test.
+    """
     path = data.path
     tblname = tbl.name
 
@@ -184,25 +231,19 @@ def create_hive(dialect, tbl, data, dshape=None, **kwargs):
     return statement.format(**locals())
 
 
-@resource.register('hive://.+::.+', priority=16)
-def resource_hive_table(uri, **kwargs):
-    uri, table = uri.split('::')
-    engine = resource(uri, **kwargs)
-    metadata = metadata_of_engine(engine)
-    if table in metadata.tables:
-        return metadata.tables[table]
-    metadata.reflect(engine, views=False)
-    if table in metadata.tables:
-        return metadata.tables[table]
-    return TableProxy(engine, table)
-
-
-TableProxy = namedtuple('TableProxy', 'engine,name')
-
-
 @append.register(TableProxy, HDFS(Directory(CSV)))
 def create_new_hive_table_from_csv(tbl, data, **kwargs):
-    statement = create_command(tbl.engine.dialect.name, tbl, data, **kwargs)
+    """
+    Create new Hive table from directory of CSV files on HDFS
+
+    Actually executes command.
+    """
+    if tbl.engine.dialect.name == 'hive':
+        statement = create_hive_from_hdfs_directory_of_csvs(tbl, data, **kwargs)
+    else:
+        raise NotImplementedError("Don't know how to migrate directory of csvs"
+                " on HDFS to database of dialect %s" % tbl.engine.dialect.name)
+
     with tbl.engine.connect() as conn:
         conn.execute(statement)
 
@@ -210,3 +251,103 @@ def create_new_hive_table_from_csv(tbl, data, **kwargs):
     tbl2 = sa.Table(tbl.name, metadata, autoload=True,
             autoload_with=tbl.engine)
     return tbl2
+
+
+"""
+Load Remote data into Hive
+==========================
+
+We push types like SSH(CSV) and SSH(Directory(CSV)) into Hive tables.
+
+Often our data is on the cluster but not on HDFS.  There are slightly different
+CREATE TABLE and LOAD commands in this case.
+
+Note that there is a *lot* of code duplication to what we just saw above.  I'm
+not sure yet how best to refactor this.  There are a lot of annoying bits to
+work around that have so far pushed me to write ugly code.
+"""
+from .ssh import SSH
+
+def create_hive_from_remote_csv_file(tbl, data, dshape=None, **kwargs):
+    path = data.path
+    tblname = tbl.name
+
+    dialect = merge(dialect_of(data), kwargs)
+
+    # Get sample text
+    with sample(data) as fn:
+        text = open(fn).read()
+
+    # Handle header, dialect
+    if 'has_header' not in dialect:
+        dialect['has_header'] = sniffer.has_header(text)
+
+    d = sniffer.sniff(text)
+    delimiter = dialect.get('delimiter', d.delimiter)
+    escapechar = dialect.get('escapechar', d.escapechar)
+    lineterminator = dialect.get('lineterminator', d.lineterminator)
+    quotechar = dialect.get('quotechar', d.quotechar)
+
+    dbname = str(tbl.engine.url).split('/')[-1]
+    if dbname:
+        dbname = dbname + '.'
+
+    # Column names and types from datashape
+    ds = dshape or discover(data)
+    assert isinstance(ds.measure, ct.Record)
+    columns = [(name, dshape_to_hive(typ))
+            for name, typ in zip(ds.measure.names, ds.measure.types)]
+    column_text = ',\n'.join('%30s  %s' % col for col in columns)[12:]
+
+    statement = """
+        CREATE TABLE {dbname}{tblname} (
+            {column_text}
+            )
+        ROW FORMAT DELIMITED
+            FIELDS TERMINATED BY '{delimiter}'
+        STORED AS TEXTFILE
+        """
+
+    if dialect.get('has_header'):
+        statement = statement + """
+        TBLPROPERTIES ("skip.header.line.count"="1")"""
+
+    return statement.format(**locals())
+
+
+@append.register(sa.Table, (SSH(CSV), SSH(Directory(CSV))))
+def append_remote_csv_to_table(tbl, csv, **kwargs):
+    if tbl.bind.uri.dialect:
+        statement = ('LOAD DATA LOCAL INPATH %{path}s INTO TABLE %{tablename}s' %
+                {'path': csv.path, 'tablename': tbl.name})
+    else:
+        raise NotImplementedError("Don't know how to migrate csvs on remote "
+                "disk to database of dialect %s" % tbl.engine.dialect.name)
+    with tbl.bind.connect() as conn:
+        conn.execute(statement)
+    return tbl
+
+
+@append.register(TableProxy, (SSH(CSV), SSH(Directory(CSV))))
+def create_and_append_remote_csv_to_table(tbl, csv, **kwargs):
+    if tbl.engine.dialect.name == 'hive':
+        statement = create_hive_from_remote_csv_file(tbl, data, **kwargs)
+    else:
+        raise NotImplementedError("Don't know how to migrate csvs on remote "
+                "disk to database of dialect %s" % tbl.engine.dialect.name)
+
+    with tbl.engine.connect() as conn:
+        conn.execute(statement)
+
+    metadata = metadata_of_engine(tbl.engine)
+    tbl2 = sa.Table(tbl.name, metadata, autoload=True,
+            autoload_with=tbl.engine)
+    return tbl2
+
+
+def dialect_of(data):
+    if isinstance(data, CSV):
+        return data.dialect
+    if isinstance(data, _Directory):
+        return data.kwargs
+    raise NotImplementedError()

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -129,7 +129,7 @@ hive_types = {
         ct.int8: 'TINYINT',
         ct.int16: 'SMALLINT',
         ct.int32: 'INT',
-        ct.int64: 'SMALLINT',
+        ct.int64: 'BIGINT',
         ct.float32: 'FLOAT',
         ct.float64: 'DOUBLE',
         ct.date_: 'DATE',
@@ -143,8 +143,8 @@ def dshape_to_hive(ds):
 
     >>> dshape_to_hive('int16')
     'SMALLINT'
-    >>> dshape_to_hive('?int16')  # Ignore option types
-    'SMALLINT'
+    >>> dshape_to_hive('?int32')  # Ignore option types
+    'INT'
     >>> dshape_to_hive('string[256]')
     'VARCHAR(256)'
     """

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -232,7 +232,7 @@ def create_hive_statement(tbl_name, dshape, path=None, table_type='',
     assert isinstance(ds.measure, ct.Record)
     columns = [(name, dshape_to_hive(typ))
             for name, typ in zip(ds.measure.names, ds.measure.types)]
-    column_text = ',\n'.join('%20s  %s' % col for col in columns)[12:]
+    column_text = ',\n    '.join('%20s  %s' % col for col in columns).lstrip()
 
     statement = """
         CREATE {table_type} TABLE {db_name}{tbl_name} (

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -71,6 +71,8 @@ def dshape_to_hive(ds):
 
     >>> dshape_to_hive('int16')
     'SMALLINT'
+    >>> dshape_to_hive('?int16')  # Ignore option types
+    'SMALLINT'
     >>> dshape_to_hive('string[256]')
     'VARCHAR(256)'
     """
@@ -78,6 +80,8 @@ def dshape_to_hive(ds):
         ds = datashape.dshape(ds)
     if isinstance(ds, ct.DataShape):
         ds = ds.measure
+    if isinstance(ds, ct.Option):
+        ds = ds.ty
     if isinstance(ds, ct.String):
         if ds.fixlen:
             return 'VARCHAR(%d)' % ds.fixlen

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -1,0 +1,51 @@
+from toolz import memoize
+from functools import wraps
+
+from .csv import CSV
+from datashape import discover
+from pywebhdfs.webhdfs import PyWebHdfsClient
+from ..utils import tmpfile
+
+class _HDFS(object):
+    """ Parent class for data on Hadoop File System
+
+    Examples
+    --------
+
+    >>> from into import HDFS, CSV
+    >>> HDFS(CSV)('/path/to/file.csv')
+    """
+    def __init__(self, *args, **kwargs):
+        hdfs = kwargs.pop('hdfs', None)
+        host = kwargs.pop('host', None)
+        port = kwargs.pop('port', '14000')
+        user = kwargs.pop('user', 'hdfs')
+
+        if not hdfs and (host and port and user):
+            hdfs = PyWebHdfsClient(host=host, port=port, user_name=user)
+
+        if hdfs is None:
+            raise ValueError("No HDFS credentials found.\n"
+                    "Either supply a PyWebHdfsClient instance or keywords\n"
+                    "   host=, port=, user=")
+        self.hdfs = hdfs
+
+        self.subtype.__init__(self, *args, **kwargs)
+
+
+
+@memoize
+def HDFS(cls):
+    return type('HDFS(%s)' % cls.__name__, (_HDFS, cls), {'subtype':  cls})
+
+
+@discover.register(HDFS(CSV))
+def discover_hdfs_csv(data, length=10000, **kwargs):
+    sample = data.hdfs.read_file(data.path.lstrip('/'), length=length)
+    with tmpfile('.csv') as fn:
+        with open(fn, 'w') as f:
+            f.write(sample)
+        result = discover(CSV(fn, encoding=data.encoding,
+                                  dialect=data.dialect,
+                                  has_header=data.has_header))
+    return result

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -2,7 +2,9 @@ from toolz import memoize
 from functools import wraps
 
 from .csv import CSV
+import datashape
 from datashape import discover
+from datashape import coretypes as ct
 from pywebhdfs.webhdfs import PyWebHdfsClient
 from ..utils import tmpfile
 
@@ -49,3 +51,78 @@ def discover_hdfs_csv(data, length=10000, **kwargs):
                                   dialect=data.dialect,
                                   has_header=data.has_header))
     return result
+
+
+hive_types = {
+        ct.int8: 'TINYINT',
+        ct.int16: 'SMALLINT',
+        ct.int32: 'INT',
+        ct.int64: 'SMALLINT',
+        ct.float32: 'FLOAT',
+        ct.float64: 'DOUBLE',
+        ct.date_: 'DATE',
+        ct.datetime_: 'TIMESTAMP',
+        ct.string: 'STRING',
+        ct.bool_: 'BOOLEAN'}
+
+
+def dshape_to_hive(ds):
+    """ Convert datashape measure to Hive dtype string
+
+    >>> dshape_to_hive('int16')
+    'SMALLINT'
+    >>> dshape_to_hive('string[256]')
+    'VARCHAR(256)'
+    """
+    if isinstance(ds, (str, unicode)):
+        ds = datashape.dshape(ds)
+    if isinstance(ds, ct.DataShape):
+        ds = ds.measure
+    if isinstance(ds, ct.String):
+        if ds.fixlen:
+            return 'VARCHAR(%d)' % ds.fixlen
+        else:
+            return 'STRING'
+    if ds in hive_types:
+        return hive_types[ds]
+    raise NotImplementedError("No Hive dtype known for %s" % ds)
+
+
+from ..regex import RegexDispatcher
+create_command = RegexDispatcher('create_command')
+
+@create_command.register('hive')
+def copy_hive(dialect, tbl, csv, dshape=None):
+    path = csv.path
+    tblname = tbl.table_name
+    dbname = tbl.db_name
+    if dbname:
+        dbname = dbname + '.'
+    delimiter = csv.dialect.get('delimiter', ',')
+    quotechar = csv.dialect.get('quotechar', '"')
+    escapechar = csv.dialect.get('escapechar', '\\')
+    encoding = csv.encoding or 'utf-8'
+
+    ds = dshape or discover(csv)
+    assert isinstance(ds.measure, ct.Record)
+    columns = [(name, dshape_to_hive(typ))
+            for name, typ in zip(ds.measure.names, ds.measure.types)]
+    column_text = ',\n'.join('%30s  %s' % col for col in columns)[12:]
+
+    statement = """
+        CREATE TABLE {dbname}{tblname} (
+            {column_text}
+            )
+        ROW FORMAT FIELDS DELIMITED BY {delimiter}
+                   ESCAPED BY {escapechar}
+        STORED AS TEXTFILE
+        LOCATION '{path}'
+        """
+
+    if csv.has_header:
+        statement = statement + """
+        TBLPROPERTIES ("skip.header.line.count"="1")"""
+
+    statement = statement + ';'
+
+    return statement.format(**locals())

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -67,6 +67,7 @@ def resource_ssh(uri, **kwargs):
         uri = uri[len('ssh://'):]
 
     d = re.match(ssh_pattern, uri).groupdict()
+    d = dict((k, v) for k, v in d.items() if v is not None)
     path = d.pop('path')
 
     kwargs.update(d)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import, division, print_function
+
+import paramiko
+from contextlib import contextmanager
+from toolz import keyfilter, memoize, take
+from datashape import discover
+import re
+
+from ..utils import keywords, tmpfile
+from ..resource import resource
+
+
+class _SSH(object):
+    """ Parent class for data accessed through ssh
+
+    See ``paramiko.SSHClient.connect`` for authentication keyword arguments
+
+    Examples
+    --------
+
+    >>> from into import SSH, CSV
+    >>> SSH(CSV)('/path/to/file.csv')
+
+    Normally create through resource uris
+
+    >>> data = resource('ssh://alice@hostname:/path/to/file.csv')
+    >>> data.path
+    '/path/to/file.csv'
+    >>> data.hostname
+    'hostname'
+    """
+    def __init__(self, *args, **kwargs):
+        self.auth = keyfilter(keywords(paramiko.SSHClient.connect).__contains__,
+                              kwargs)
+        self.subtype.__init__(self, *args, **kwargs)
+
+    @memoize
+    def connect(self):
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(**self.auth)
+        return ssh
+
+    def lines(self):
+        ssh = self.connect()
+        sftp = ssh.open_sftp()
+        return sftp.file(self.path, 'r')
+
+
+def SSH(cls):
+    return type('SSH(%s)' % cls.__name__, (_SSH, cls), {'subtype':  cls})
+
+SSH.__doc__ = _SSH.__doc__
+
+SSH = memoize(SSH)
+
+
+from .csv import CSV
+from .json import JSONLines
+types_by_extension = {'csv': CSV, 'json': JSONLines}
+
+
+@resource.register('ssh://.+', priority=14)
+def resource_ssh(uri, **kwargs):
+    if 'ssh://' in uri:
+        uri = uri[len('ssh://'):]
+
+    pattern = '((?P<username>[a-zA-Z]\w*)@)?(?P<hostname>[a-zA-Z][\w.-]*)(:(?P<port>\d+))?:(?P<path>[/\w.-]+)'
+    d = re.match(pattern, uri).groupdict()
+    path = d.pop('path')
+
+    kwargs.update(d)
+
+    try:
+        subtype = types_by_extension[path.split('.')[-1]]
+    except KeyError:
+        subtype = type(resource(path))
+
+    return SSH(subtype)(path, **kwargs)
+
+
+@contextmanager
+def sample(data, lines=500):
+    """ Grab a few lines from the remote file """
+    with tmpfile() as fn:
+        with open(fn, 'w') as f:
+            for line in take(lines, data.lines()):
+                f.write(line)
+                f.write('\n')
+        yield fn
+
+
+@discover.register(_SSH)
+def discover_ssh(data, **kwargs):
+    with sample(data) as fn:
+        o = data.subtype(fn)
+        result = discover(o)
+    return result
+
+
+@discover.register(SSH(CSV))
+def discover_ssh_csv(data, **kwargs):
+    with sample(data) as fn:
+        o = CSV(fn, encoding=data.encoding, has_header=data.has_header, **data.dialect)
+        result = discover(o)
+    return result

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -59,14 +59,14 @@ from .csv import CSV
 from .json import JSONLines
 types_by_extension = {'csv': CSV, 'json': JSONLines}
 
+ssh_pattern = '((?P<username>[a-zA-Z]\w*)@)?(?P<hostname>[\w.-]*)(:(?P<port>\d+))?:(?P<path>[/\w.-]+)'
 
 @resource.register('ssh://.+', priority=14)
 def resource_ssh(uri, **kwargs):
     if 'ssh://' in uri:
         uri = uri[len('ssh://'):]
 
-    pattern = '((?P<username>[a-zA-Z]\w*)@)?(?P<hostname>[a-zA-Z][\w.-]*)(:(?P<port>\d+))?:(?P<path>[/\w.-]+)'
-    d = re.match(pattern, uri).groupdict()
+    d = re.match(ssh_pattern, uri).groupdict()
     path = d.pop('path')
 
     kwargs.update(d)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -11,7 +11,7 @@ from ..resource import resource
 
 
 class _SSH(object):
-    """ Parent class for data accessed through ssh
+    """ Parent class for data accessed through ``ssh``
 
     See ``paramiko.SSHClient.connect`` for authentication keyword arguments
 
@@ -19,15 +19,15 @@ class _SSH(object):
     --------
 
     >>> from into import SSH, CSV
-    >>> SSH(CSV)('/path/to/file.csv')
+    >>> s = SSH(CSV)('/path/to/file.csv', hostname='hostname', username='alice')
 
     Normally create through resource uris
 
-    >>> data = resource('ssh://alice@hostname:/path/to/file.csv')
+    >>> data = resource('ssh://alice@host:/path/to/file.csv', password='pass')
     >>> data.path
     '/path/to/file.csv'
-    >>> data.hostname
-    'hostname'
+    >>> data.auth['hostname']
+    'host'
     """
     def __init__(self, *args, **kwargs):
         self.auth = keyfilter(keywords(paramiko.SSHClient.connect).__contains__,

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -10,6 +10,7 @@ from ..directory import _Directory, Directory
 from ..utils import keywords, tmpfile, sample
 from ..resource import resource
 from ..append import append
+from ..drop import drop
 
 
 class _SSH(object):
@@ -130,6 +131,13 @@ def discover_ssh_directory(data, **kwargs):
     fn = data.path + '/' + sftp.listdir(data.path)[0]
     one_file = SSH(data.container)(fn, **data.auth)
     return discover(one_file)
+
+
+@drop.register(_SSH)
+def drop_ssh(data, **kwargs):
+    ssh = data.connect()
+    sftp = ssh.open_sftp()
+    sftp.remove(data.path)
 
 
 @append.register(_SSH, object)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -60,9 +60,9 @@ from .csv import CSV
 from .json import JSONLines
 types_by_extension = {'csv': CSV, 'json': JSONLines}
 
-ssh_pattern = '((?P<username>[a-zA-Z]\w*)@)?(?P<hostname>[\w.-]*)(:(?P<port>\d+))?:(?P<path>[/\w.-]+)'
+ssh_pattern = '((?P<username>[a-zA-Z]\w*)@)?(?P<hostname>[\w.-]*)(:(?P<port>\d+))?:(?P<path>[/\w.*-]+)'
 
-@resource.register('ssh://.+', priority=14)
+@resource.register('ssh://.+', priority=16)
 def resource_ssh(uri, **kwargs):
     if 'ssh://' in uri:
         uri = uri[len('ssh://'):]
@@ -75,6 +75,9 @@ def resource_ssh(uri, **kwargs):
 
     try:
         subtype = types_by_extension[path.split('.')[-1]]
+        if '*' in path:
+            subtype = Directory(subtype)
+            path = path.rsplit('/', 1)[0] + '/'
     except KeyError:
         subtype = type(resource(path))
 

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -1,0 +1,40 @@
+from into.backends.hdfs import discover, HDFS, CSV, create_command
+from into.backends.sql import resource
+import sqlalchemy as sa
+from pywebhdfs.webhdfs import PyWebHdfsClient
+from datashape import dshape
+from collections import namedtuple
+
+
+hdfs = PyWebHdfsClient(host='54.91.57.226', port='14000', user_name='hdfs')
+data = HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
+ProxyTable = namedtuple('ProxyTable', 'table_name,db_name')
+
+
+def test_discover():
+    assert discover(data) == \
+            dshape('var * {Name: string, RegistrationDate: datetime, ZipCode: int64, Consts: float64}')
+
+
+def normalize(s):
+    return ' '.join(s.split())
+
+def test_create_hive():
+
+    text = create_command('hive', ProxyTable('mytable', 'mydb'), data)
+    expected = r"""
+        CREATE TABLE mydb.mytable (
+                          Name  STRING,
+              RegistrationDate  TIMESTAMP,
+                       ZipCode  SMALLINT,
+                        Consts  DOUBLE
+            )
+        ROW FORMAT FIELDS DELIMITED BY ,
+                   ESCAPED BY \
+        STORED AS TEXTFILE
+        LOCATION '/user/hive/warehouse/csv_test/data.csv'
+
+        TBLPROPERTIES ("skip.header.line.count"="1");
+        """
+
+    assert normalize(text) == normalize(expected)

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -1,4 +1,6 @@
-from into.backends.hdfs import discover, HDFS, CSV, create_command, TableProxy
+from into.backends.hdfs import (discover, HDFS, CSV,
+        create_hive_from_hdfs_directory_of_csvs,
+        create_hive_from_remote_csv_file, TableProxy, SSH)
 from into.backends.sql import resource
 import sqlalchemy as sa
 from pywebhdfs.webhdfs import PyWebHdfsClient
@@ -6,17 +8,16 @@ from datashape import dshape
 from into.directory import Directory
 
 hdfs = PyWebHdfsClient(host='54.91.57.226', port='14000', user_name='hdfs')
-data = HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
-directory = HDFS(Directory(CSV))('/user/hive/mrocklin/accounts/', hdfs=hdfs)
+hdfs_csv= HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
+hdfs_directory = HDFS(Directory(CSV))('/user/hive/mrocklin/accounts/', hdfs=hdfs)
 engine = resource('hive://hdfs@54.91.57.226:10000/default')
 
-
 def test_discover():
-    assert discover(data) == \
+    assert discover(hdfs_csv) == \
             dshape('var * {Name: string, RegistrationDate: datetime, ZipCode: int64, Consts: float64}')
 
 def test_discover_hdfs_directory():
-    assert discover(directory) == \
+    assert discover(hdfs_directory) == \
             dshape('var * {id: int64, name: string, amount: int64}')
 
 
@@ -24,7 +25,8 @@ def normalize(s):
     return ' '.join(s.split())
 
 def test_create_hive():
-    text = create_command('hive', TableProxy(engine, 'mytable'), directory)
+    text = create_hive_from_hdfs_directory_of_csvs(
+            TableProxy(engine, 'mytable'), hdfs_directory)
     expected = r"""
         CREATE EXTERNAL TABLE default.mytable (
                       id  SMALLINT,
@@ -35,6 +37,52 @@ def test_create_hive():
             FIELDS TERMINATED BY ','
         STORED AS TEXTFILE
         LOCATION '/user/hive/mrocklin/accounts/'
+
+        TBLPROPERTIES ("skip.header.line.count"="1")
+        """
+
+    assert normalize(text) == normalize(expected)
+
+
+auth = {'hostname': '54.91.57.226',
+        'key_filename': '/home/mrocklin/.ssh/cdh_testing.key',
+        'username': 'ubuntu'}
+
+ssh_csv= SSH(CSV)('accounts.csv', **auth)
+ssh_directory = SSH(Directory(CSV))('mrocklin/', **auth)
+
+
+def test_create_hive_from_remote_csv_file():
+    tbl = TableProxy(engine, 'mytable')
+    ds = discover(ssh_directory)
+    text = create_hive_from_remote_csv_file(tbl, ssh_directory, dshape=ds)
+
+    expected = r"""
+        CREATE TABLE default.mytable (
+                      id  SMALLINT,
+                    name  STRING,
+                  amount  SMALLINT
+            )
+        ROW FORMAT DELIMITED
+            FIELDS TERMINATED BY ','
+        STORED AS TEXTFILE
+
+        TBLPROPERTIES ("skip.header.line.count"="1")
+        """
+
+    assert normalize(text) == normalize(expected)
+
+    text = create_hive_from_remote_csv_file(tbl, ssh_csv, dshape=ds)
+
+    expected = r"""
+        CREATE TABLE default.mytable (
+                      id  SMALLINT,
+                    name  STRING,
+                  amount  SMALLINT
+            )
+        ROW FORMAT DELIMITED
+            FIELDS TERMINATED BY ','
+        STORED AS TEXTFILE
 
         TBLPROPERTIES ("skip.header.line.count"="1")
         """

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -1,8 +1,6 @@
-from into.backends.hdfs import (discover, HDFS, CSV,
-        create_hive_from_hdfs_directory_of_csvs,
-        create_hive_from_remote_csv_file, TableProxy, SSH)
+from into.backends.hdfs import (discover, HDFS, CSV, TableProxy, SSH)
 from into.backends.sql import resource
-from into import into
+from into import into, drop
 import sqlalchemy as sa
 from pywebhdfs.webhdfs import PyWebHdfsClient
 from datashape import dshape
@@ -12,6 +10,7 @@ from into.directory import Directory
 hdfs = PyWebHdfsClient(host='54.91.57.226', port='14000', user_name='hdfs')
 hdfs_csv= HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
 hdfs_directory = HDFS(Directory(CSV))('/user/hive/mrocklin/accounts/', hdfs=hdfs)
+ds = dshape('var * {id: ?int64, name: ?string, amount: ?int64}')
 engine = resource('hive://hdfs@54.91.57.226:10000/default')
 
 
@@ -27,102 +26,57 @@ def test_discover_hdfs_directory():
 def normalize(s):
     return ' '.join(s.split())
 
-def test_create_hive():
-    text = create_hive_from_hdfs_directory_of_csvs(
-            TableProxy(engine, 'mytable'), hdfs_directory)
-    expected = r"""
-        CREATE EXTERNAL TABLE default.mytable (
-                      id  BIGINT,
-                    name  STRING,
-                  amount  BIGINT
-            )
-        ROW FORMAT DELIMITED
-            FIELDS TERMINATED BY ','
-        STORED AS TEXTFILE
-        LOCATION '/user/hive/mrocklin/accounts/'
-
-        TBLPROPERTIES ("skip.header.line.count"="1")
-        """
-
-    assert normalize(text) == normalize(expected)
-
 
 auth = {'hostname': '54.91.57.226',
         'key_filename': '/home/mrocklin/.ssh/cdh_testing.key',
         'username': 'ubuntu'}
 
-ssh_csv= SSH(CSV)('accounts.csv', **auth)
-ssh_directory = SSH(Directory(CSV))('mrocklin/', **auth)
+ssh_csv= SSH(CSV)('/home/ubuntu/accounts.csv', **auth)
+ssh_directory = SSH(Directory(CSV))('/home/ubuntu/mrocklin/', **auth)
 
 
-def test_create_hive_from_remote_csv_file():
-    tbl = TableProxy(engine, 'mytable')
-    ds = discover(ssh_directory)
-    text = create_hive_from_remote_csv_file(tbl, ssh_directory, dshape=ds)
-
-    expected = r"""
-        CREATE TABLE default.mytable (
-                      id  BIGINT,
-                    name  STRING,
-                  amount  BIGINT
-            )
-        ROW FORMAT DELIMITED
-            FIELDS TERMINATED BY ','
-        STORED AS TEXTFILE
-
-        TBLPROPERTIES ("skip.header.line.count"="1")
-        """
-
-    assert normalize(text) == normalize(expected)
-
-    text = create_hive_from_remote_csv_file(tbl, ssh_csv, dshape=ds)
-
-    expected = r"""
-        CREATE TABLE default.mytable (
-                      id  BIGINT,
-                    name  STRING,
-                  amount  BIGINT
-            )
-        ROW FORMAT DELIMITED
-            FIELDS TERMINATED BY ','
-        STORED AS TEXTFILE
-
-        TBLPROPERTIES ("skip.header.line.count"="1")
-        """
-
-    assert normalize(text) == normalize(expected)
+def test_hdfs_hive_creation():
+    uri = 'hive://hdfs@54.91.57.226:10000/default::hdfs_directory_1'
+    try:
+        t = into(uri, hdfs_directory)
+        assert isinstance(t, sa.Table)
+        assert len(into(list, t)) > 0
+        assert discover(t) == ds
+    finally:
+        drop(t)
 
 
 def test_ssh_hive_creation():
+    uri = 'hive://hdfs@54.91.57.226:10000/default::ssh_1'
     try:
-        drop('hive://hdfs@54.91.57.226:10000/default::tmp_1')
-    except:
-        pass
+        t = into(uri, ssh_csv)
+        assert isinstance(t, sa.Table)
+        assert len(into(list, t)) > 0
+    finally:
+        drop(t)
 
-    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_1', ssh_csv)
-    assert isinstance(t, sa.Table)
-    assert len(into(list, t)) == 5
 
 
 def test_ssh_directory_hive_creation():
+    uri = 'hive://hdfs@54.91.57.226:10000/default::ssh_2'
     try:
-        drop('hive://hdfs@54.91.57.226:10000/default::tmp_2')
-    except:
-        pass
+        t = into(uri, ssh_directory)
+        assert isinstance(t, sa.Table)
+        assert discover(t) == ds
+        assert len(into(list, t)) > 0
+        assert len(into(list, t)) == 8
 
-    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_2', ssh_directory)
-    assert isinstance(t, sa.Table)
-    assert discover(t) == discover(ssh_directory)
-    assert len(into(list, t)) == 8
+    finally:
+        drop(t)
 
 
 def test_ssh_hive_creation_with_full_urls():
+    uri = 'hive://hdfs@54.91.57.226:10000/default::ssh_3'
     try:
-        drop('hive://hdfs@54.91.57.226:10000/default::tmp_3')
-    except:
-        pass
-    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_3',
-             'ssh://ubuntu@54.91.57.226:accounts.csv',
-             key_filename='/home/mrocklin/.ssh/cdh_testing.key')
-    assert isinstance(t, sa.Table)
-    assert len(into(list, t)) == 5
+        t = into(uri, 'ssh://ubuntu@54.91.57.226:/home/ubuntu/accounts.csv',
+                 key_filename='/home/mrocklin/.ssh/cdh_testing.key')
+        assert isinstance(t, sa.Table)
+        assert len(into(list, t)) > 0
+        assert len(into(list, t)) == 5
+    finally:
+        drop(t)

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -8,10 +8,12 @@ from pywebhdfs.webhdfs import PyWebHdfsClient
 from datashape import dshape
 from into.directory import Directory
 
+
 hdfs = PyWebHdfsClient(host='54.91.57.226', port='14000', user_name='hdfs')
 hdfs_csv= HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
 hdfs_directory = HDFS(Directory(CSV))('/user/hive/mrocklin/accounts/', hdfs=hdfs)
 engine = resource('hive://hdfs@54.91.57.226:10000/default')
+
 
 def test_discover():
     assert discover(hdfs_csv) == \
@@ -30,9 +32,9 @@ def test_create_hive():
             TableProxy(engine, 'mytable'), hdfs_directory)
     expected = r"""
         CREATE EXTERNAL TABLE default.mytable (
-                      id  SMALLINT,
+                      id  BIGINT,
                     name  STRING,
-                  amount  SMALLINT
+                  amount  BIGINT
             )
         ROW FORMAT DELIMITED
             FIELDS TERMINATED BY ','
@@ -60,9 +62,9 @@ def test_create_hive_from_remote_csv_file():
 
     expected = r"""
         CREATE TABLE default.mytable (
-                      id  SMALLINT,
+                      id  BIGINT,
                     name  STRING,
-                  amount  SMALLINT
+                  amount  BIGINT
             )
         ROW FORMAT DELIMITED
             FIELDS TERMINATED BY ','
@@ -77,9 +79,9 @@ def test_create_hive_from_remote_csv_file():
 
     expected = r"""
         CREATE TABLE default.mytable (
-                      id  SMALLINT,
+                      id  BIGINT,
                     name  STRING,
-                  amount  SMALLINT
+                  amount  BIGINT
             )
         ROW FORMAT DELIMITED
             FIELDS TERMINATED BY ','
@@ -110,6 +112,7 @@ def test_ssh_directory_hive_creation():
 
     t = into('hive://hdfs@54.91.57.226:10000/default::tmp_2', ssh_directory)
     assert isinstance(t, sa.Table)
+    assert discover(t) == discover(ssh_directory)
     assert len(into(list, t)) == 8
 
 

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -2,6 +2,7 @@ from into.backends.hdfs import (discover, HDFS, CSV,
         create_hive_from_hdfs_directory_of_csvs,
         create_hive_from_remote_csv_file, TableProxy, SSH)
 from into.backends.sql import resource
+from into import into
 import sqlalchemy as sa
 from pywebhdfs.webhdfs import PyWebHdfsClient
 from datashape import dshape
@@ -88,3 +89,37 @@ def test_create_hive_from_remote_csv_file():
         """
 
     assert normalize(text) == normalize(expected)
+
+
+def test_ssh_hive_creation():
+    try:
+        drop('hive://hdfs@54.91.57.226:10000/default::tmp_1')
+    except:
+        pass
+
+    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_1', ssh_csv)
+    assert isinstance(t, sa.Table)
+    assert len(into(list, t)) == 5
+
+
+def test_ssh_directory_hive_creation():
+    try:
+        drop('hive://hdfs@54.91.57.226:10000/default::tmp_2')
+    except:
+        pass
+
+    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_2', ssh_directory)
+    assert isinstance(t, sa.Table)
+    assert len(into(list, t)) == 8
+
+
+def test_ssh_hive_creation_with_full_urls():
+    try:
+        drop('hive://hdfs@54.91.57.226:10000/default::tmp_3')
+    except:
+        pass
+    t = into('hive://hdfs@54.91.57.226:10000/default::tmp_3',
+             'ssh://ubuntu@54.91.57.226:accounts.csv',
+             key_filename='/home/mrocklin/.ssh/cdh_testing.key')
+    assert isinstance(t, sa.Table)
+    assert len(into(list, t)) == 5

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -71,8 +71,6 @@ def test_ssh_directory_hive_creation():
         assert isinstance(t, sa.Table)
         assert discover(t) == ds
         assert len(into(list, t)) > 0
-        assert len(into(list, t)) == 8
-
     finally:
         drop(t)
 
@@ -94,3 +92,12 @@ def test_ssh_hive_creation_with_full_urls():
         assert len(into(list, t)) == 2 * n
     finally:
         drop(t)
+
+
+def test_hive_resource():
+    db = resource('hive://hdfs@%s:10000/default' % host)
+    assert isinstance(db, sa.engine.Engine)
+
+    db = resource('hive://%s/' % host)
+    assert isinstance(db, sa.engine.Engine)
+    assert str(db.url) == 'hive://hdfs@%s:10000/default' % host

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -3,23 +3,26 @@ from into.backends.sql import resource
 import sqlalchemy as sa
 from pywebhdfs.webhdfs import PyWebHdfsClient
 from datashape import dshape
-from collections import namedtuple
-
+from into.directory import Directory
 
 hdfs = PyWebHdfsClient(host='54.91.57.226', port='14000', user_name='hdfs')
 data = HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)
-ProxyTable = namedtuple('ProxyTable', 'table_name,db_name')
+directory = HDFS(Directory(CSV))('/user/hive/mrocklin/accounts/', hdfs=hdfs)
 
 
 def test_discover():
     assert discover(data) == \
             dshape('var * {Name: string, RegistrationDate: datetime, ZipCode: int64, Consts: float64}')
 
+def test_discover_hdfs_directory():
+    assert discover(directory) == \
+            dshape('var * {id: int64, name: string, amount: int64}')
+
 
 def normalize(s):
     return ' '.join(s.split())
 
-def test_create_hive():
+def dont_test_create_hive():
 
     engine = sa.create_engine('sqlite:///:memory:')
     text = create_command('hive', TableProxy('mytable', engine), data)

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -1,8 +1,13 @@
+try:
+    from pywebhdfs.webhdfs import PyWebHdfsClient
+except ImportError:
+    import pytest
+    pytest.importorskip('does_not_exist')
+
 from into.backends.hdfs import (discover, HDFS, CSV, TableProxy, SSH)
 from into.backends.sql import resource
 from into import into, drop
 import sqlalchemy as sa
-from pywebhdfs.webhdfs import PyWebHdfsClient
 from datashape import dshape
 from into.directory import Directory
 import os

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -21,7 +21,8 @@ def normalize(s):
 
 def test_create_hive():
 
-    text = create_command('hive', ProxyTable('mytable', 'mydb'), data)
+    engine = sa.create_engine('sqlite:///:memory:')
+    text = create_command('hive', TableProxy('mytable', engine), data)
     expected = r"""
         CREATE TABLE mydb.mytable (
                           Name  STRING,

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -260,3 +260,12 @@ def test_engine_metadata_caching():
 
         assert a.metadata is b.metadata
         assert engine is a.bind is b.bind
+
+
+def test_hive_resource():
+    db = resource('hive://hdfs@54.91.57.226:10000/default')
+    assert isinstance(db, sa.engine.Engine)
+
+    db = resource('hive://54.91.57.226/')
+    assert isinstance(db, sa.engine.Engine)
+    assert str(db.url) == 'hive://hdfs@54.91.57.226:10000/default'

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -260,12 +260,3 @@ def test_engine_metadata_caching():
 
         assert a.metadata is b.metadata
         assert engine is a.bind is b.bind
-
-
-def test_hive_resource():
-    db = resource('hive://hdfs@54.91.57.226:10000/default')
-    assert isinstance(db, sa.engine.Engine)
-
-    db = resource('hive://54.91.57.226/')
-    assert isinstance(db, sa.engine.Engine)
-    assert str(db.url) == 'hive://hdfs@54.91.57.226:10000/default'

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -1,12 +1,20 @@
 import paramiko
 
-
 from into.utils import tmpfile, filetext, filetexts, raises
 from into.directory import _Directory, Directory
 from into.backends.ssh import *
 from into import into
 import re
 import os
+
+
+try:
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(hostname='localhost')
+except:
+    import pytest
+    pytest.importorskip('a_library_that_does_not_exist')  # Punt on testing
 
 
 def test_resource():

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -14,6 +14,15 @@ def test_resource():
     assert r.auth['username'] == 'joe'
 
 
+def test_resource_directory():
+    r = resource('ssh://joe@localhost:/path/to/')
+    assert issubclass(r.subtype, _Directory)
+
+    r = resource('ssh://joe@localhost:/path/to/*.csv')
+    assert r.subtype == Directory(CSV)
+    assert r.path == '/path/to/'
+
+
 def test_discover():
     with filetext('name,balance\nAlice,100\nBob,200') as fn:
         local = CSV(fn)
@@ -34,6 +43,7 @@ def test_ssh_pattern():
     uris = ['localhost:myfile.csv',
             '127.0.0.1:/myfile.csv',
             'user@127.0.0.1:/myfile.csv',
+            'user@127.0.0.1:/*.csv',
             'user@127.0.0.1:/my-dir/my-file3.csv']
     for uri in uris:
         assert re.match(ssh_pattern, uri)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -6,6 +6,7 @@ from into.directory import _Directory, Directory
 from into.backends.ssh import *
 from into import into
 import re
+import os
 
 
 def test_resource():
@@ -63,3 +64,22 @@ def test_copy_remote_csv():
             # Round trip
             csv2 = into(target, scsv)
             assert into(list, csv) == into(list, csv2)
+
+
+def test_drop():
+    with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
+        with tmpfile('csv') as target:
+            csv = CSV(fn)
+            scsv = SSH(CSV)(target, hostname='localhost')
+
+            assert not os.path.exists(target)
+
+            ssh = scsv.connect()
+            sftp = ssh.open_sftp()
+            sftp.put(fn, target)
+
+            assert os.path.exists(target)
+
+            drop(scsv)
+
+            assert not os.path.exists(target)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -1,0 +1,21 @@
+import paramiko
+
+
+from into.utils import tmpfile, filetext, filetexts, raises
+from into.backends.ssh import *
+
+
+def test_resource():
+    r = resource('ssh://joe@localhost:/path/to/myfile.csv')
+    assert isinstance(r, SSH(CSV))
+    assert r.path == '/path/to/myfile.csv'
+    assert r.auth['hostname'] == 'localhost'
+    assert r.auth['username'] == 'joe'
+
+
+def test_discover():
+    with filetext('name,balance\nAlice,100\nBob,200') as fn:
+        local = CSV(fn)
+        remote = SSH(CSV)(fn, hostname='localhost')
+
+        assert discover(local) == discover(remote)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -74,9 +74,8 @@ def test_drop():
 
             assert not os.path.exists(target)
 
-            ssh = scsv.connect()
-            sftp = ssh.open_sftp()
-            sftp.put(fn, target)
+            with sftp(**scsv.auth) as conn:
+                conn.put(fn, target)
 
             assert os.path.exists(target)
 

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -2,6 +2,7 @@ import paramiko
 
 
 from into.utils import tmpfile, filetext, filetexts, raises
+from into.directory import _Directory, Directory
 from into.backends.ssh import *
 import re
 

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -4,6 +4,7 @@ import paramiko
 from into.utils import tmpfile, filetext, filetexts, raises
 from into.directory import _Directory, Directory
 from into.backends.ssh import *
+from into import into
 import re
 
 
@@ -48,3 +49,17 @@ def test_ssh_pattern():
             'user@127.0.0.1:/my-dir/my-file3.csv']
     for uri in uris:
         assert re.match(ssh_pattern, uri)
+
+
+def test_copy_remote_csv():
+    with tmpfile('csv') as target:
+        with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
+            csv = resource(fn)
+            scsv = into('ssh://localhost:foo.csv', csv)
+            assert isinstance(scsv, SSH(CSV))
+            assert discover(scsv) == discover(csv)
+
+
+            # Round trip
+            csv2 = into(target, scsv)
+            assert into(list, csv) == into(list, csv2)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -22,6 +22,14 @@ def test_discover():
         assert discover(local) == discover(remote)
 
 
+def test_discover_from_resource():
+    with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
+        local = CSV(fn)
+        remote = resource('ssh://localhost:' + fn)
+
+        assert discover(local) == discover(remote)
+
+
 def test_ssh_pattern():
     uris = ['localhost:myfile.csv',
             '127.0.0.1:/myfile.csv',

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -3,6 +3,7 @@ import paramiko
 
 from into.utils import tmpfile, filetext, filetexts, raises
 from into.backends.ssh import *
+import re
 
 
 def test_resource():
@@ -19,3 +20,12 @@ def test_discover():
         remote = SSH(CSV)(fn, hostname='localhost')
 
         assert discover(local) == discover(remote)
+
+
+def test_ssh_pattern():
+    uris = ['localhost:myfile.csv',
+            '127.0.0.1:/myfile.csv',
+            'user@127.0.0.1:/myfile.csv',
+            'user@127.0.0.1:/my-dir/my-file3.csv']
+    for uri in uris:
+        assert re.match(ssh_pattern, uri)

--- a/into/directory.py
+++ b/into/directory.py
@@ -11,14 +11,19 @@ import os
 class _Directory(Chunks):
     """ A directory of files on disk
 
-    >>> d = _Directory('path/to/data')
-
     For typed containers see the ``Directory`` function which generates
     parametrized Directory classes.
 
-    >>> c = Directory(CSV)('path/to/data')
-    """
+    >>> from into import Directory, CSV
+    >>> c = Directory(CSV)('path/to/data/')
 
+    Normal use through resource strings
+
+    >>> r = resource('path/to/data/*.csv')
+    >>> r = resource('path/to/data/')
+
+
+    """
     def __init__(self, path, **kwargs):
         self.path = path
         self.kwargs = kwargs
@@ -40,3 +45,18 @@ Directory = memoize(Directory)
 @discover.register(_Directory)
 def discover_Directory(c, **kwargs):
     return var * discover(first(c)).subshape[0]
+
+
+@resource.register('.+/\*\..+', priority=15)
+def resource_directory(uri, **kwargs):
+    one_uri = first(glob(uri))
+    subtype = type(resource(one_uri, **kwargs))
+    path = uri.rsplit('/', 1)[0]
+    return Directory(subtype)(path, **kwargs)
+
+
+@resource.register('.+/', priority=15)
+def resource_directory_with_trailing_slash(uri, **kwargs):
+    one_uri = os.listdir(uri)[0]
+    subtype = type(resource(one_uri, **kwargs))
+    return Directory(subtype)(uri, **kwargs)

--- a/into/directory.py
+++ b/into/directory.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function
+
+from glob import glob
+from .chunks import Chunks
+from .resource import resource
+from toolz import memoize, first
+from datashape import discover, var
+import os
+
+
+class _Directory(Chunks):
+    """ A directory of files on disk
+
+    >>> d = _Directory('path/to/data')
+
+    For typed containers see the ``Directory`` function which generates
+    parametrized Directory classes.
+
+    >>> c = Directory(CSV)('path/to/data')
+    """
+
+    def __init__(self, path, **kwargs):
+        self.path = path
+        self.kwargs = kwargs
+
+    def __iter__(self):
+        return (resource(os.path.join(self.path, fn), **self.kwargs)
+                    for fn in sorted(os.listdir(self.path)))
+
+
+def Directory(cls):
+    """ Parametrized DirectoryClass """
+    return type('Directory(%s)' + cls.__name__, (_Directory,), {'container': cls})
+
+Directory.__doc__ = Directory.__doc__
+
+Directory = memoize(Directory)
+
+
+@discover.register(_Directory)
+def discover_Directory(c, **kwargs):
+    return var * discover(first(c)).subshape[0]

--- a/into/directory.py
+++ b/into/directory.py
@@ -14,7 +14,7 @@ class _Directory(Chunks):
     For typed containers see the ``Directory`` function which generates
     parametrized Directory classes.
 
-    >>> from into import Directory, CSV
+    >>> from into import CSV
     >>> c = Directory(CSV)('path/to/data/')
 
     Normal use through resource strings
@@ -52,7 +52,7 @@ def resource_directory(uri, **kwargs):
     path = uri.rsplit(os.path.sep, 1)[0]
     try:
         one_uri = first(glob(uri))
-    except OSError:
+    except (OSError, StopIteration):
         return _Directory(path, **kwargs)
     subtype = type(resource(one_uri, **kwargs))
     return Directory(subtype)(path, **kwargs)
@@ -62,7 +62,7 @@ def resource_directory(uri, **kwargs):
 def resource_directory_with_trailing_slash(uri, **kwargs):
     try:
         one_uri = os.listdir(uri)[0]
-    except OSError:
+    except (OSError, IndexError):
         return _Directory(uri, **kwargs)
     subtype = type(resource(one_uri, **kwargs))
     return Directory(subtype)(uri, **kwargs)

--- a/into/directory.py
+++ b/into/directory.py
@@ -58,7 +58,7 @@ def resource_directory(uri, **kwargs):
     return Directory(subtype)(path, **kwargs)
 
 
-@resource.register('.+' + os.path.sep, priority=15)
+@resource.register('.+' + os.path.sep, priority=12)
 def resource_directory_with_trailing_slash(uri, **kwargs):
     try:
         one_uri = os.listdir(uri)[0]

--- a/into/directory.py
+++ b/into/directory.py
@@ -30,7 +30,7 @@ class _Directory(Chunks):
 
 def Directory(cls):
     """ Parametrized DirectoryClass """
-    return type('Directory(%s)' + cls.__name__, (_Directory,), {'container': cls})
+    return type('Directory(%s)' % cls.__name__, (_Directory,), {'container': cls})
 
 Directory.__doc__ = Directory.__doc__
 

--- a/into/directory.py
+++ b/into/directory.py
@@ -47,16 +47,22 @@ def discover_Directory(c, **kwargs):
     return var * discover(first(c)).subshape[0]
 
 
-@resource.register('.+/\*\..+', priority=15)
+@resource.register('.+' + os.path.sep + '\*\..+', priority=15)
 def resource_directory(uri, **kwargs):
-    one_uri = first(glob(uri))
+    path = uri.rsplit(os.path.sep, 1)[0]
+    try:
+        one_uri = first(glob(uri))
+    except OSError:
+        return _Directory(path, **kwargs)
     subtype = type(resource(one_uri, **kwargs))
-    path = uri.rsplit('/', 1)[0]
     return Directory(subtype)(path, **kwargs)
 
 
-@resource.register('.+/', priority=15)
+@resource.register('.+' + os.path.sep, priority=15)
 def resource_directory_with_trailing_slash(uri, **kwargs):
-    one_uri = os.listdir(uri)[0]
+    try:
+        one_uri = os.listdir(uri)[0]
+    except OSError:
+        return _Directory(uri, **kwargs)
     subtype = type(resource(one_uri, **kwargs))
     return Directory(subtype)(uri, **kwargs)

--- a/into/directory.py
+++ b/into/directory.py
@@ -58,7 +58,7 @@ def resource_directory(uri, **kwargs):
     return Directory(subtype)(path, **kwargs)
 
 
-@resource.register('.+' + os.path.sep, priority=12)
+@resource.register('.+' + os.path.sep, priority=9)
 def resource_directory_with_trailing_slash(uri, **kwargs):
     try:
         one_uri = os.listdir(uri)[0]

--- a/into/into.py
+++ b/into/into.py
@@ -8,6 +8,7 @@ from .resource import resource
 from datashape import discover, var
 from datashape.dispatch import namespace
 from datashape.predicates import isdimension
+from .compatibility import unicode
 
 
 if 'into' not in namespace:

--- a/into/into.py
+++ b/into/into.py
@@ -52,6 +52,8 @@ def into_object(a, b, **kwargs):
     into.append.append      - Add things onto existing things
     into.resource.resource  - Specify things with strings
     """
+    if isinstance(b, (str, unicode)):
+        b = resource(b, **kwargs)
     try:
         if 'dshape' not in kwargs:
             kwargs['dshape'] = discover(b)

--- a/into/tests/test_directory.py
+++ b/into/tests/test_directory.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import, division, print_function
+
+import tempfile
+from contextlib import contextmanager
+import shutil
+from into.backends.csv import CSV
+from into.directory import Directory, discover
+from into import into
+from datashape import dshape
+import os
+
+@contextmanager
+def csvs(n=3):
+    path = tempfile.mktemp()
+    os.mkdir(path)
+
+    fns = ['%s/file_%d.csv' % (path, i) for i in range(n)]
+
+    for i, fn in enumerate(fns):
+        into(fn, [{'a': i, 'b': j} for j in range(5)])
+
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
+
+
+def test_discover():
+    with csvs() as path:
+        d = Directory(CSV)(path)
+        assert discover(d) == dshape('var * {a: int64, b: int64}')

--- a/into/tests/test_directory.py
+++ b/into/tests/test_directory.py
@@ -4,7 +4,7 @@ import tempfile
 from contextlib import contextmanager
 import shutil
 from into.backends.csv import CSV
-from into.directory import Directory, discover, resource
+from into.directory import Directory, discover, resource, _Directory
 from into import into
 from datashape import dshape
 import os
@@ -40,3 +40,7 @@ def test_resource_directory():
         r2 = resource(os.path.join(path, '*.csv'))
         assert type(r) == Directory(CSV)
         assert r2.path.rstrip(os.path.sep) == path.rstrip(os.path.sep)
+
+
+def test_resource_directory():
+    assert isinstance(resource('/a/directory/that/doesnt/exist/'), _Directory)

--- a/into/tests/test_into.py
+++ b/into/tests/test_into.py
@@ -1,5 +1,6 @@
 from into.into import into
 from into.utils import tmpfile, filetext
+from into.backends.csv import CSV
 
 def test_into_convert():
     assert into(list, (1, 2, 3)) == [1, 2, 3]
@@ -19,7 +20,6 @@ def test_into_curry():
 
 
 def test_into_double_string():
-    from into.backends.csv import CSV
     with filetext('alice,1\nbob,2', extension='.csv') as source:
         assert into(list, source) == [('alice', 1), ('bob', 2)]
 
@@ -28,3 +28,8 @@ def test_into_double_string():
             assert isinstance(csv, CSV)
             with open(target) as f:
                 assert 'alice' in f.read()
+
+
+def test_into_string_on_right():
+    with filetext('alice,1\nbob,2', extension='.csv') as source:
+        assert into([], source) == [('alice', 1), ('bob', 2)]

--- a/into/utils.py
+++ b/into/utils.py
@@ -203,3 +203,5 @@ def tuples_to_records(ds, data):
     raise NotImplementedError()
 
 
+from multipledispatch import Dispatcher
+sample = Dispatcher('sample')

--- a/recommended-requirements.txt
+++ b/recommended-requirements.txt
@@ -9,3 +9,4 @@ h5py
 pymongo
 bcolz
 sas7bdat
+paramiko


### PR DESCRIPTION
Starting an HDFS component to `into`.  Counterpoint to work done by @cpcloud on AWS

The goal is to 

1.  Create new types for remote data that allow us to cleanly leverage our existing logic
2.  Automate some migration and data loading on foreign hardware.

See discussion here:

https://github.com/ContinuumIO/into/issues/29
https://github.com/ContinuumIO/into/issues/34

```Python
In [1]: from into import HDFS, CSV, discover

In [2]: from pywebhdfs.webhdfs import PyWebHdfsClient

In [3]: hdfs = PyWebHdfsClient(host='123.123.123.123', port='14000', user_name='hdfs')

In [4]: data = HDFS(CSV)('/user/hive/warehouse/csv_test/data.csv', hdfs=hdfs)

In [5]: discover(data)
Out[5]: 
dshape("""var * {
  Name: string,
  RegistrationDate: datetime,
  ZipCode: int64,
  Consts: float64
  }""")
```

HDFS work done by @quasiben 