### PR TITLE
Cache sql engines

### DIFF
--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -112,7 +112,7 @@ def discover(engine):
 
 @dispatch(sa.MetaData)
 def discover(metadata):
-    metadata.reflect(views=True)
+    metadata.reflect(views=metadata.bind.dialect.supports_views)
     pairs = []
     for name, table in sorted(metadata.tables.items(), key=first):
         try:
@@ -310,7 +310,7 @@ def resource_sql(uri, *args, **kwargs):
     if args and isinstance(args[0], str):
         table_name, args = args[0], args[1:]
         metadata = metadata_of_engine(engine)
-        metadata.reflect(views=True)
+        metadata.reflect(views=engine.dialect.supports_views)
         if table_name not in metadata.tables:
             if ds:
                 t = dshape_to_table(table_name, ds, metadata)

--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -95,6 +95,9 @@ def metadata_of_engine(engine):
     return metadata
 
 
+create_engine = memoize(sa.create_engine)
+
+
 @dispatch(sa.engine.base.Engine, str)
 def discover(engine, tablename):
     metadata = metadata_of_engine(engine)
@@ -305,7 +308,7 @@ def append_select_statement_to_sql_Table(t, o, **kwargs):
 def resource_sql(uri, *args, **kwargs):
     kwargs2 = keyfilter(keywords(sa.create_engine).__contains__,
                        kwargs)
-    engine = sa.create_engine(uri, **kwargs2)
+    engine = create_engine(uri, **kwargs2)
     ds = kwargs.get('dshape')
     if args and isinstance(args[0], str):
         table_name, args = args[0], args[1:]

--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -95,7 +95,14 @@ def metadata_of_engine(engine):
     return metadata
 
 
-create_engine = memoize(sa.create_engine)
+def create_engine(uri, *args, **kwargs):
+    if ':memory:' in uri:
+        return sa.create_engine(uri, *args, **kwargs)
+    else:
+        return memoized_create_engine(uri, *args, **kwargs)
+
+
+memoized_create_engine = memoize(sa.create_engine)
 
 
 @dispatch(sa.engine.base.Engine, str)

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -241,3 +241,13 @@ def test_append_from_select(sqlite_file):
     result = into(list, t)
     expected = np.concatenate((raw, raw2)).tolist()
     assert result == expected
+
+
+def test_engine_metadata_caching():
+    with tmpfile('db') as fn:
+        engine = resource('sqlite:///' + fn)
+        a = resource('sqlite:///' + fn + '::a', dshape=dshape('var * {x: int}'))
+        b = resource('sqlite:///' + fn + '::b', dshape=dshape('var * {y: int}'))
+
+        assert a.metadata is b.metadata
+        assert engine is a.bind is b.bind


### PR DESCRIPTION
Previously we were creating many sqlalchemy engines and reflecting many metadata instances.  This can become quite expensive.  Here use use some judicious calls to `memoize`.