### PR TITLE
use with ignoring context manager

### DIFF
--- a/into/__init__.py
+++ b/into/__init__.py
@@ -4,6 +4,7 @@ from multipledispatch import halt_ordering, restart_ordering
 
 halt_ordering() # Turn off multipledispatch ordering
 
+from .utils import ignoring
 from .convert import convert
 from .append import append
 from .resource import resource
@@ -15,62 +16,34 @@ from datashape import discover, dshape
 from collections import Iterator
 import numpy as np
 
-try:
+with ignoring(ImportError):
      from .backends.sas import sas7bdat
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.pandas import pd
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.bcolz import bcolz
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.h5py import h5py
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.hdfstore import HDFStore
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.pytables import tables
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.dynd import nd
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends import sql
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends import mongo
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.csv import CSV
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.json import JSON, JSONLines
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.hdfs import HDFS
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends.ssh import SSH
-except:
-    pass
-try:
+with ignoring(ImportError):
      from .backends import sql_csv
-except:
-    pass
 
 
 restart_ordering() # Restart multipledispatch ordering and do ordering

--- a/into/backends/hdfs.py
+++ b/into/backends/hdfs.py
@@ -12,16 +12,16 @@ from collections import namedtuple
 from contextlib import contextmanager
 from .ssh import SSH, _SSH
 from .sql import metadata_of_engine, sa
-from ..utils import tmpfile, sample
+from ..utils import tmpfile, sample, ignoring
 from ..append import append
 from ..resource import resource
 from ..directory import _Directory, Directory
 from ..compatibility import unicode
 
-try:
+
+with ignoring(ImportError):
     from pywebhdfs.webhdfs import PyWebHdfsClient
-except ImportError:
-    pass
+
 
 class _HDFS(object):
     """ Parent class for data on Hadoop File System

--- a/into/core.py
+++ b/into/core.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import networkx as nx
 from datashape import discover
-from .utils import expand_tuples, cls_name
+from .utils import expand_tuples, cls_name, ignoring
 from contextlib import contextmanager
 
 
@@ -34,11 +34,9 @@ def _transform(graph, target, source, excluded_edges=None, ooc_types=ooc_types,
     """ Transform source to target type using graph of transformations """
     x = source
     excluded_edges = excluded_edges or set()
-    try:
+    with ignoring(NotImplementedError):
         if 'dshape' not in kwargs:
             kwargs['dshape'] = discover(x)
-    except NotImplementedError:
-        pass
     pth = path(graph, type(source), target,
                excluded_edges=excluded_edges,
                ooc_types=ooc_types)

--- a/into/into.py
+++ b/into/into.py
@@ -5,6 +5,7 @@ from multipledispatch import Dispatcher
 from .convert import convert
 from .append import append
 from .resource import resource
+from .utils import ignoring
 from datashape import discover, var
 from datashape.dispatch import namespace
 from datashape.predicates import isdimension
@@ -18,11 +19,9 @@ into = namespace['into']
 
 @into.register(type, object)
 def into_type(a, b, **kwargs):
-    try:
+    with ignoring(NotImplementedError):
         if 'dshape' not in kwargs:
             kwargs['dshape'] = discover(b)
-    except NotImplementedError:
-        pass
     return convert(a, b, **kwargs)
 
 
@@ -55,11 +54,9 @@ def into_object(a, b, **kwargs):
     """
     if isinstance(b, (str, unicode)):
         b = resource(b, **kwargs)
-    try:
+    with ignoring(NotImplementedError):
         if 'dshape' not in kwargs:
             kwargs['dshape'] = discover(b)
-    except NotImplementedError:
-        pass
     return append(a, b, **kwargs)
 
 

--- a/into/utils.py
+++ b/into/utils.py
@@ -203,5 +203,13 @@ def tuples_to_records(ds, data):
     raise NotImplementedError()
 
 
+@contextmanager
+def ignoring(*exceptions):
+    try:
+        yield
+    except exceptions:
+        pass
+
+
 from multipledispatch import Dispatcher
 sample = Dispatcher('sample')


### PR DESCRIPTION
Adds a context manager `ignoring` which runs code in a `try-except-pass` block.

```python
with ignoring(ImportError):
    from foo import bar
```

Same as

```Python
try:
    from foo import bar
except ImportError:
    pass
```

Mostly I just thought that this was neat.  Not sure if it warrants adding a new term.