### PR TITLE
Parametrized Temp type

### DIFF
--- a/into/__init__.py
+++ b/into/__init__.py
@@ -11,6 +11,7 @@ from .resource import resource
 from .directory import Directory
 from .into import into
 from .drop import drop
+from .temp import Temp
 from .chunks import chunks, Chunks
 from datashape import discover, dshape
 from collections import Iterator

--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -20,6 +20,7 @@ from ..append import append
 from ..convert import convert, ooc_types
 from ..resource import resource
 from ..chunks import chunks
+from ..temp import Temp
 from ..numpy_dtype import dshape_to_pandas
 from .pandas import coerce_datetimes
 
@@ -104,7 +105,7 @@ def ext(path):
     return e.lstrip('.')
 
 
-@convert.register(pd.DataFrame, CSV, cost=20.0)
+@convert.register(pd.DataFrame, (Temp(CSV), CSV), cost=20.0)
 def csv_to_DataFrame(c, dshape=None, chunksize=None, nrows=None, **kwargs):
     try:
         return _csv_to_DataFrame(c, dshape=dshape,
@@ -174,7 +175,7 @@ def _csv_to_DataFrame(c, dshape=None, chunksize=None, **kwargs):
                              **kwargs2)
 
 
-@convert.register(chunks(pd.DataFrame), CSV, cost=10.0)
+@convert.register(chunks(pd.DataFrame), (Temp(CSV), CSV), cost=10.0)
 def CSV_to_chunks_of_dataframes(c, chunksize=2**20, **kwargs):
     # Load a small 1000 line DF to start
     # This helps with rapid viewing of a large CSV file
@@ -234,7 +235,7 @@ def resource_glob(uri, **kwargs):
     return chunks(type(r))(_)
 
 
-@convert.register(chunks(pd.DataFrame), chunks(CSV), cost=10.0)
+@convert.register(chunks(pd.DataFrame), (chunks(CSV), chunks(Temp(CSV))), cost=10.0)
 def convert_glob_of_csvs_to_chunks_of_dataframes(csvs, **kwargs):
     def _():
         return concat(convert(chunks(pd.DataFrame), csv, **kwargs) for csv in csvs)

--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -14,6 +14,7 @@ import pandas as pd
 import os
 import gzip
 import bz2
+import uuid
 
 from ..utils import keywords
 from ..append import append
@@ -240,6 +241,13 @@ def convert_glob_of_csvs_to_chunks_of_dataframes(csvs, **kwargs):
     def _():
         return concat(convert(chunks(pd.DataFrame), csv, **kwargs) for csv in csvs)
     return chunks(pd.DataFrame)(_)
+
+
+@convert.register(Temp(CSV), (pd.DataFrame, chunks(pd.DataFrame)))
+def convert_dataframes_to_temporary_csv(data, **kwargs):
+    fn = '.%s.csv' % uuid.uuid1()
+    csv = Temp(CSV)(fn, **kwargs)
+    return append(csv, data, **kwargs)
 
 
 @dispatch(CSV)

--- a/into/backends/json.py
+++ b/into/backends/json.py
@@ -15,6 +15,7 @@ from ..append import append
 from ..convert import convert, ooc_types
 from ..resource import resource
 from ..chunks import chunks
+from ..temp import Temp
 from ..utils import tuples_to_records
 
 
@@ -90,12 +91,12 @@ def discover_jsonlines(j, n=10, encoding='utf-8', **kwargs):
 
 
 
-@convert.register(list, JSON)
+@convert.register(list, (JSON, Temp(JSON)))
 def json_to_list(j, dshape=None, **kwargs):
     return json_load(j.path, **kwargs)
 
 
-@convert.register(Iterator, JSONLines)
+@convert.register(Iterator, (JSONLines, Temp(JSONLines)))
 def json_lines_to_iterator(j, encoding='utf-8', **kwargs):
     with json_lines(j.path, encoding=encoding) as lines:
         for item in pipe(lines, filter(nonempty), map(json.loads)):
@@ -258,14 +259,14 @@ def json_dumps(dt):
     return dt.isoformat()
 
 
-@convert.register(chunks(list), chunks(JSON))
+@convert.register(chunks(list), (chunks(JSON), chunks(Temp(JSON))))
 def convert_glob_of_jsons_into_chunks_of_lists(jsons, **kwargs):
     def _():
         return concat(convert(chunks(list), js, **kwargs) for js in jsons)
     return chunks(list)(_)
 
 
-@convert.register(chunks(Iterator), chunks(JSONLines))
+@convert.register(chunks(Iterator), (chunks(JSONLines), chunks(Temp(JSONLines))))
 def convert_glob_of_jsons_into_chunks_of_lists(jsons, **kwargs):
     def _():
         return concat(convert(chunks(Iterator), js, **kwargs) for js in jsons)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -159,7 +159,7 @@ def drop_ssh(data, **kwargs):
 @append.register(_SSH, object)
 def append_anything_to_ssh(target, source, **kwargs):
     if not isinstance(source, target.subtype):
-        raise NotImplementedError() # TODO: create local temp
+        source = convert(Temp(target.subtype), source, **kwargs)
     # TODO: handle overwrite case
     with sftp(**target.auth) as conn:
         conn.put(source.path, target.path)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -5,11 +5,14 @@ from contextlib import contextmanager
 from toolz import keyfilter, memoize, take
 from datashape import discover
 import re
-from ..directory import _Directory, Directory
+import uuid
 
+from ..directory import _Directory, Directory
 from ..utils import keywords, tmpfile, sample
 from ..resource import resource
 from ..append import append
+from ..convert import convert
+from ..temp import Temp
 from ..drop import drop
 
 
@@ -171,3 +174,10 @@ def append_sshX_to_X(target, source, **kwargs):
     with sftp(**source.auth) as conn:
         conn.get(source.path, target.path)
     return target
+
+
+@convert.register(Temp(SSH(CSV)), (Temp(CSV), CSV))
+def csv_to_temp_ssh_csv(data, **kwargs):
+    fn = '.%s.csv' % uuid.uuid1()
+    target = Temp(SSH(CSV))(fn, **kwargs)
+    return append(target, data, **kwargs)

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -162,7 +162,7 @@ def discover_ssh_directory(data, **kwargs):
     return result
 
 
-@drop.register(_SSH)
+@drop.register((_SSH, SSH(CSV), SSH(JSON), SSH(JSONLines)))
 def drop_ssh(data, **kwargs):
     with sftp(**data.auth) as conn:
         conn.remove(data.path)

--- a/into/backends/tests/test_csv.py
+++ b/into/backends/tests/test_csv.py
@@ -11,7 +11,7 @@ from collections import Iterator
 from into.backends.csv import (CSV, append, convert, resource,
         csv_to_DataFrame, CSV_to_chunks_of_dataframes)
 from into.utils import tmpfile, filetext, filetexts, raises
-from into import into, append, convert, resource, discover, dshape
+from into import into, append, convert, resource, discover, dshape, Temp
 from into.compatibility import unicode, skipif
 
 
@@ -263,3 +263,19 @@ def test_csv_separator_header():
     with filetext('a|b|c\n1|2|3\n4|5|6', extension='csv') as fn:
         csv = CSV(fn, delimiter='|', has_header=True)
         assert convert(list, csv) == [(1, 2, 3), (4, 5, 6)]
+
+
+def test_temp_csv():
+    df = pd.DataFrame([['Alice',   100],
+                       ['Bob',     200],
+                       ['Charlie', 300]],
+                      columns=['name', 'balance'])
+    csv = into(Temp(CSV)('_test_temp_csv.csv'), df)
+    assert isinstance(csv, CSV)
+
+    assert into(list, csv) == into(list, df)
+
+    del csv
+    import gc
+    gc.collect()
+    assert not os.path.exists('_test_temp_csv.csv')

--- a/into/backends/tests/test_csv.py
+++ b/into/backends/tests/test_csv.py
@@ -12,6 +12,7 @@ from into.backends.csv import (CSV, append, convert, resource,
         csv_to_DataFrame, CSV_to_chunks_of_dataframes)
 from into.utils import tmpfile, filetext, filetexts, raises
 from into import into, append, convert, resource, discover, dshape, Temp
+from into.temp import _Temp
 from into.compatibility import unicode, skipif
 
 
@@ -265,11 +266,13 @@ def test_csv_separator_header():
         assert convert(list, csv) == [(1, 2, 3), (4, 5, 6)]
 
 
+df = pd.DataFrame([['Alice',   100],
+                   ['Bob',     200],
+                   ['Charlie', 300]],
+                  columns=['name', 'balance'])
+
+
 def test_temp_csv():
-    df = pd.DataFrame([['Alice',   100],
-                       ['Bob',     200],
-                       ['Charlie', 300]],
-                      columns=['name', 'balance'])
     csv = into(Temp(CSV)('_test_temp_csv.csv'), df)
     assert isinstance(csv, CSV)
 
@@ -279,3 +282,11 @@ def test_temp_csv():
     import gc
     gc.collect()
     assert not os.path.exists('_test_temp_csv.csv')
+
+
+def test_convert_to_csv():
+    csv = into(Temp(CSV), df)
+    assert isinstance(csv, CSV)
+
+    assert into(list, csv) == into(list, df)
+    assert isinstance(csv, _Temp)

--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -43,8 +43,8 @@ auth = {'hostname': host,
         'key_filename': os.path.expanduser('~/.ssh/cdh_testing.key'),
         'username': 'ubuntu'}
 
-ssh_csv= SSH(CSV)('/home/ubuntu/accounts.csv', **auth)
-ssh_directory = SSH(Directory(CSV))('/home/ubuntu/mrocklin/', **auth)
+ssh_csv= SSH(CSV)('/home/ubuntu/into-testing/accounts1.csv', **auth)
+ssh_directory = SSH(Directory(CSV))('/home/ubuntu/into-testing/', **auth)
 
 
 def test_hdfs_hive_creation():
@@ -68,7 +68,6 @@ def test_ssh_hive_creation():
         drop(t)
 
 
-
 def test_ssh_directory_hive_creation():
     uri = 'hive://hdfs@%s:10000/default::ssh_2' % host
     try:
@@ -84,14 +83,14 @@ def test_ssh_hive_creation_with_full_urls():
     uri = 'hive://hdfs@%s:10000/default::ssh_3' % host
     try:
         t = into(uri, 'ssh://ubuntu@%s:accounts.csv' % host,
-                 key_filename='/home/mrocklin/.ssh/cdh_testing.key')
+                 key_filename=os.path.expanduser('~/.ssh/cdh_testing.key'))
         assert isinstance(t, sa.Table)
         n = len(into(list, t))
         assert n > 0
 
         # Load it again
         into(t, 'ssh://ubuntu@%s:accounts.csv' % host,
-             key_filename='/home/mrocklin/.ssh/cdh_testing.key')
+             key_filename=os.path.expanduser('~/.ssh/cdh_testing.key'))
 
         # Doubles length
         assert len(into(list, t)) == 2 * n

--- a/into/backends/tests/test_json.py
+++ b/into/backends/tests/test_json.py
@@ -1,9 +1,11 @@
 from into.backends.json import *
 from into.utils import tmpfile
 from into import into
+from into.temp import Temp, _Temp
 from contextlib import contextmanager
 from datashape import dshape
 import datetime
+import os
 import gzip
 import os
 import json
@@ -205,3 +207,21 @@ def test_resource_gzip():
     assert isinstance(resource('json://foo.json.gz'), (JSON, JSONLines))
     assert isinstance(resource('jsonlines://foo.json.gz'), (JSON, JSONLines))
     assert isinstance(resource('jsonlines://foo.jsonlines.gz'), (JSON, JSONLines))
+
+
+def test_convert_to_temp_json():
+    js = convert(Temp(JSON), [1, 2, 3])
+    assert isinstance(js, JSON)
+    assert isinstance(js, _Temp)
+
+    assert convert(list, js) == [1, 2, 3]
+
+
+def test_drop():
+    with tmpfile('json') as fn:
+        js = JSON(fn)
+        append(js, [1, 2, 3])
+
+        assert os.path.exists(fn)
+        drop(js)
+        assert not os.path.exists(fn)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -96,6 +96,12 @@ def test_drop():
             assert not os.path.exists(target)
 
 
+def test_drop_of_csv_json_lines_use_ssh_version():
+    from into.backends.ssh import drop_ssh
+    for typ in [CSV, JSON, JSONLines]:
+        assert drop.dispatch(SSH(typ)) == drop_ssh
+
+
 def test_temp_ssh_files():
     with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
         csv = CSV(fn)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -3,6 +3,7 @@ import paramiko
 from into.utils import tmpfile, filetext, filetexts, raises
 from into.directory import _Directory, Directory
 from into.backends.ssh import *
+from into.temp import _Temp, Temp
 from into import into
 import re
 import os
@@ -90,3 +91,12 @@ def test_drop():
             drop(scsv)
 
             assert not os.path.exists(target)
+
+
+def test_temp_ssh_files():
+    with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
+        csv = CSV(fn)
+        scsv = into(Temp(SSH(CSV)), csv, hostname='localhost')
+        assert discover(csv) == discover(scsv)
+
+        assert isinstance(scsv, _Temp)

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -7,6 +7,7 @@ from into import CSV, JSONLines
 from into.backends.ssh import *
 from into.temp import _Temp, Temp
 from into import into
+import numpy as np
 import re
 import os
 
@@ -105,7 +106,7 @@ def test_temp_ssh_files():
 
 
 def test_convert_through_temporary_local_storage():
-    with filetext('name,balance\nAlice,100\nBob,200', extension='csv') as fn:
+    with filetext('name,quantity\nAlice,100\nBob,200', extension='csv') as fn:
         csv = CSV(fn)
         df = into(pd.DataFrame, csv)
         scsv = into(Temp(SSH(CSV)), csv, hostname='localhost')
@@ -116,4 +117,4 @@ def test_convert_through_temporary_local_storage():
         assert into(list, scsv2) == into(list, df)
 
         sjson = into(Temp(SSH(JSONLines)), df, hostname='localhost')
-        assert into(list, sjson) == into(list, df)
+        assert (into(np.ndarray, sjson) == into(np.ndarray, df)).all()

--- a/into/temp.py
+++ b/into/temp.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function
+from toolz import memoize
+from .drop import drop
+
+class _Temp(object):
+    """ Temporary version of persistent storage
+
+    Calls ``drop`` on object at garbage collection
+
+    This is a parametrized type, so call it on types to make new types
+
+    >>> from into import Temp, CSV
+    >>> csv = Temp(CSV)('/tmp/myfile.csv', delimiter=',')
+    """
+    def __del__(self):
+        drop(self)
+
+
+def Temp(cls):
+    """ Parametrized Chunks Class """
+    return type('Temp(%s)' % cls.__name__, (_Temp, cls), {'subtype': cls})
+
+Temp.__doc__ = _Temp.__doc__
+
+Temp = memoize(Temp)

--- a/into/temp.py
+++ b/into/temp.py
@@ -18,7 +18,7 @@ class _Temp(object):
 
 def Temp(cls):
     """ Parametrized Chunks Class """
-    return type('Temp(%s)' % cls.__name__, (_Temp, cls), {'subtype': cls})
+    return type('Temp(%s)' % cls.__name__, (_Temp, cls), {'persistent_type': cls})
 
 Temp.__doc__ = _Temp.__doc__
 

--- a/into/tests/test_temp.py
+++ b/into/tests/test_temp.py
@@ -1,0 +1,24 @@
+from into.temp import Temp, _Temp
+from into.drop import drop
+
+class Foo(object):
+    pass
+
+
+flag = [0]
+
+
+@drop.register(Foo)
+def drop_foo(foo, **kwrags):
+    flag[0] = flag[0] + 1
+
+
+def test_Temp():
+    foo = Temp(Foo)()
+
+    assert isinstance(foo, Foo)
+    assert isinstance(foo, _Temp)
+
+    x = flag[0]
+    del foo
+    assert flag[0] == x + 1


### PR DESCRIPTION
For some remote data situations (AWS #35) (SSH/HDFS #44) it's convenient to make temporary versions of normally persistent formats like a temporary CSV file.

## Example

To this end we create a new parametrized type, `Temp`, used as follows:

```Python
In [1]: !cat foo.csv
name,balance
Alice,100
Bob,200
In [2]: from into import Temp, CSV, into

In [3]: csv = Temp(CSV)('foo.csv', delimiter=',')

In [4]: del csv

In [5]: !cat foo.csv
cat: foo.csv: No such file or directory
```

## Temp provides garbage collection on external resources

And so using `drop` and `Temp` we're able to tie persistent formats, like CSV, to the Python garbage collector.  They should be released as the object is released.