### PR TITLE
resource function for hdfs

### DIFF
--- a/into/backends/tests/test_hdfs.py
+++ b/into/backends/tests/test_hdfs.py
@@ -6,7 +6,7 @@ except ImportError:
 
 from into.backends.hdfs import (discover, HDFS, CSV, TableProxy, SSH)
 from into.backends.sql import resource
-from into import into, drop
+from into import into, drop, JSONLines
 import sqlalchemy as sa
 from datashape import dshape
 from into.directory import Directory
@@ -105,3 +105,19 @@ def test_hive_resource():
     db = resource('hive://%s/' % host)
     assert isinstance(db, sa.engine.Engine)
     assert str(db.url) == 'hive://hdfs@%s:10000/default' % host
+
+
+def test_hdfs_resource():
+    r = resource('hdfs://user@hostname:1234:/path/to/myfile.json')
+    assert isinstance(r, HDFS(JSONLines))
+    assert r.hdfs.user_name == 'user'
+    assert r.hdfs.host == 'hostname'
+    assert r.hdfs.port == '1234'
+    assert r.path == '/path/to/myfile.json'
+
+    assert isinstance(resource('hdfs://path/to/myfile.csv',
+                                host='host', user='user', port=1234),
+                      HDFS(CSV))
+    assert isinstance(resource('hdfs://path/to/*.csv',
+                                host='host', user='user', port=1234),
+                      HDFS(Directory(CSV)))


### PR DESCRIPTION
cc @quasiben @danielfrg

```Python
In [1]: from into import resource

In [2]: r = resource('hdfs://user@hostname:1234:/path/to/myfile.csv')

In [3]: r
Out[3]: <into.backends.hdfs.HDFS(CSV) at 0x7f4cdab27550>

In [4]: r.hdfs.user_name, r.hdfs.host, r.hdfs.port, r.path
Out[4]: ('user', 'hostname', '1234', '/path/to/myfile.csv')
```

I'm also considering swapping out the current `hdfs` `PyWebHDFS.Client` attribute for an `auth` dictionary like we do in `SSH`.  Feedback on this idea welcome