### PR TITLE
Memoize ssh connections

### DIFF
--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -43,6 +43,8 @@ def sftp(**auth):
         conn = ssh.open_sftp()
         sftp_pool[key] = conn
 
+    conn.sock.setblocking(True)
+
     return conn
 
 

--- a/into/backends/ssh.py
+++ b/into/backends/ssh.py
@@ -32,10 +32,18 @@ def connect(**auth):
         connection_pool[key] = ssh
     return ssh
 
+sftp_pool = dict()
 
 def sftp(**auth):
-    ssh = connect(**auth)
-    return ssh.open_sftp()
+    ssh = connect(**auth)  # Need to call this explicitly (can't memoize)
+    key = tuple(sorted(auth.items()))
+    if key in sftp_pool:
+        conn = sftp_pool[key]
+    else:
+        conn = ssh.open_sftp()
+        sftp_pool[key] = conn
+
+    return conn
 
 
 class _SSH(object):

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -8,7 +8,7 @@ import os
 
 from into.utils import tmpfile, filetext
 from into.directory import _Directory, Directory
-from into.backends.ssh import SSH, resource, ssh_pattern, sftp, drop
+from into.backends.ssh import SSH, resource, ssh_pattern, sftp, drop, connect
 from into.backends.csv import CSV
 from into import into, discover, CSV, JSONLines, JSON
 from into.temp import _Temp, Temp
@@ -20,6 +20,18 @@ def test_resource():
     assert r.path == '/path/to/myfile.csv'
     assert r.auth['hostname'] == 'localhost'
     assert r.auth['username'] == 'joe'
+
+
+def test_connect():
+    a = connect(hostname='localhost')
+    b = connect(hostname='localhost')
+    assert a is b
+
+    a.close()
+
+    c = connect(hostname='localhost')
+    assert a is c
+    assert c.get_transport() and c.get_transport().is_active()
 
 
 def test_resource_directory():

--- a/into/backends/tests/test_ssh.py
+++ b/into/backends/tests/test_ssh.py
@@ -78,8 +78,8 @@ def test_drop():
 
             assert not os.path.exists(target)
 
-            with sftp(**scsv.auth) as conn:
-                conn.put(fn, target)
+            conn = sftp(**scsv.auth)
+            conn.put(fn, target)
 
             assert os.path.exists(target)
 


### PR DESCRIPTION
We now memoize SSH connections keyed by authentication

This is good because it makes ssh interactions feel a lot smoother

This is bad because

1.  We don't clean up
2.  We fail completely if an ssh connection dies