### PR TITLE
DataFrames use option types on string, float, datetime

### DIFF
--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -215,7 +215,9 @@ def discover_csv(c, nrows=1000, **kwargs):
     measure = discover(df).measure
 
     # Use Series.notnull to determine Option-ness
-    measure2 = Record([[name, Option(typ) if (~df[name].notnull()).any() else typ]
+    measure2 = Record([[name, Option(typ)
+                              if (~df[name].notnull()).any()
+                              and not isinstance(typ, Option) else typ]
                       for name, typ in zip(measure.names, measure.types)])
 
     return datashape.var * measure2

--- a/into/backends/pandas.py
+++ b/into/backends/pandas.py
@@ -1,18 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
 from datashape import discover
+from datashape import (float32, float64, string, Option, Record, object_,
+        datetime_)
 import datashape
 
 import pandas as pd
 
 
+possibly_missing = set((string, datetime_, float32, float64))
+
 @discover.register(pd.DataFrame)
 def discover_dataframe(df):
-    obj = datashape.coretypes.object_
+    obj = object_
     names = list(df.columns)
     dtypes = list(map(datashape.CType.from_numpy_dtype, df.dtypes))
-    dtypes = [datashape.string if dt == obj else dt for dt in dtypes]
-    schema = datashape.Record(list(zip(names, dtypes)))
+    dtypes = [string if dt == obj else dt for dt in dtypes]
+    odtypes = [Option(dt) if dt in possibly_missing else dt
+                for dt in dtypes]
+    schema = datashape.Record(list(zip(names, odtypes)))
     return len(df) * schema
 
 

--- a/into/backends/tests/test_csv.py
+++ b/into/backends/tests/test_csv.py
@@ -133,7 +133,7 @@ def test_pandas_write_gzip():
 def test_pandas_loads_in_datetimes_naively():
     with filetext('name,when\nAlice,2014-01-01\nBob,2014-02-02') as fn:
         csv = CSV(fn, has_header=True)
-        ds = datashape.dshape('var * {name: string, when: datetime}')
+        ds = datashape.dshape('var * {name: ?string, when: ?datetime}')
         assert discover(csv) == ds
 
         df = convert(pd.DataFrame, csv)
@@ -144,7 +144,7 @@ def test_pandas_discover_on_gzipped_files():
     with filetext('name,when\nAlice,2014-01-01\nBob,2014-02-02',
             open=gzip.open, extension='.csv.gz') as fn:
         csv = CSV(fn, has_header=True)
-        ds = datashape.dshape('var * {name: string, when: datetime}')
+        ds = datashape.dshape('var * {name: ?string, when: ?datetime}')
         assert discover(csv) == ds
 
 

--- a/into/backends/tests/test_hdfstore.py
+++ b/into/backends/tests/test_hdfstore.py
@@ -113,7 +113,7 @@ def test_append_other():
     with tmpfile('.hdf5') as fn:
         x = into(np.ndarray, df)
         dset = into('hdfstore://'+fn+'::/data', x)
-        assert discover(dset) == discover(x)
+        assert discover(dset) == discover(df)
 
 
 def test_fixed_shape():

--- a/into/backends/tests/test_pandas.py
+++ b/into/backends/tests/test_pandas.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from datashape import discover, Option
 from into.backends.pandas import discover
 import pandas as pd
 from datashape import dshape
@@ -11,10 +12,17 @@ def test_discover_dataframe():
     df = pd.DataFrame([('Alice', 100), ('Bob', 200)],
                         columns=['name', 'amount'])
 
-    assert discover(df) == dshape('2 * {name: string, amount: int64}')
+    assert discover(df) == dshape('2 * {name: ?string, amount: int64}')
 
 
 def test_discover_series():
     s = pd.Series([1, 2, 3])
 
     assert discover(s) == 3 * discover(s[0])
+
+
+def test_floats_are_optional():
+    df = pd.DataFrame([('Alice', 100), ('Bob', None)],
+                        columns=['name', 'amount'])
+    ds = discover(df)
+    assert isinstance(ds[1].types[1], Option)

--- a/into/backends/tests/test_sas.py
+++ b/into/backends/tests/test_sas.py
@@ -43,7 +43,7 @@ def test_convert_sas_to_dataframe():
     # pandas doesn't support date
     expected = str(ds.measure).replace('date', 'datetime')
 
-    assert str(discover(df).measure) == expected
+    assert str(discover(df).measure).replace('?', '') == expected
 
 
 def test_convert_sas_to_list():


### PR DESCRIPTION
This used to fail

```Python
In [1]: from into import *

In [2]: df = pd.DataFrame({'name': ['Alice', 'Bob', 'Charlie'], 'balance':
[100, None, 300]})

In [3]: into('sqlite:///foo.db::foo2', df)
```

Now it doesn't.

cc @jiffyclub