### PR TITLE
Fix issues in the conda recipe bld.bat

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,7 +1,5 @@
-@echo off
-
 SET BLD_DIR=%CD%
 cd /D "%RECIPE_DIR%\.."
 FOR /F "delims=" %%i IN ('git describe --tags') DO set INTO_VERSION=%%i
-echo.%INTO_VERSION% | %PYTHON% .\conda.recipe\version.py > %SRC_DIR%\__conda_version__.txt
-%PYTHON% setup.py --quiet install
+echo.%INTO_VERSION% | "%PYTHON%" .\conda.recipe\version.py > "%SRC_DIR%\__conda_version__.txt"
+"%PYTHON%" setup.py --quiet install


### PR DESCRIPTION
Don't turn echo off (we want to see what commands cause errors).

Quote variables (conda paths can contain spaces on Windows).