### PR TITLE
Sqlite infer header

### DIFF
--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -255,4 +255,26 @@ def drop(c):
     os.unlink(c.path)
 
 
+def infer_header(csv, encoding='utf-8', **kwargs):
+    """ Guess if csv file has a header or not
+
+    This uses Pandas to read a sample of the file, then looks at the column
+    names to see if they are all word-like.
+
+    Returns True or False
+    """
+    compression = kwargs.pop('compression',
+            {'gz': 'gzip', 'bz2': 'bz2'}.get(ext(csv.path)))
+    # See read_csv docs for header for reasoning
+    try:
+        df = pd.read_csv(csv.path, encoding=encoding,
+                         compression=compression, nrows=5)
+    except StopIteration:
+        df = pd.read_csv(csv.path, encoding=encoding,
+                                  compression=compression)
+    return (len(df) > 0 and
+            all(re.match('^\s*\D\w*\s*$', n) for n in df.columns) and
+            not all(dt == 'O' for dt in df.dtypes))
+
+
 ooc_types.add(CSV)

--- a/into/backends/tests/test_csv.py
+++ b/into/backends/tests/test_csv.py
@@ -9,7 +9,7 @@ from datashape import Option, string
 from collections import Iterator
 
 from into.backends.csv import (CSV, append, convert, resource,
-        csv_to_DataFrame, CSV_to_chunks_of_dataframes)
+        csv_to_DataFrame, CSV_to_chunks_of_dataframes, infer_header)
 from into.utils import tmpfile, filetext, filetexts, raises
 from into import into, append, convert, resource, discover, dshape, Temp
 from into.temp import _Temp
@@ -300,3 +300,10 @@ def test_unicode_column_names():
     with filetext('foo\xc4\x87,a\n1,2\n3,4', extension='csv') as fn:
         csv = CSV(fn, has_header=True)
         df = into(pd.DataFrame, csv)
+
+
+def test_infer_header():
+    with filetext('name,val\nAlice,100\nNA,200', extension='csv') as fn:
+        assert infer_header(CSV(fn)) == True
+    with filetext('Alice,100\nNA,200', extension='csv') as fn:
+        assert infer_header(CSV(fn)) == False

--- a/into/backends/tests/test_sqlite_into.py
+++ b/into/backends/tests/test_sqlite_into.py
@@ -2,16 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from datashape import dshape
+from datashape import dshape, discover
 from into.backends.csv import CSV
 from into import into, resource
-from into.utils import tmpfile
+from into.utils import tmpfile, filetext
 import sqlalchemy
-
-
-@pytest.yield_fixture
-def engine():
-    tbl = 'testtable'
 
 
 ds = dshape('var *  {a: int32, b: int32}' )
@@ -41,3 +36,20 @@ def test_simple_into(csv):
 
         assert sqlite_tbl_names[0][0] == tbl
         assert into(list, t) == data
+
+
+def test_csv_with_header():
+    with tmpfile('db') as dbfilename:
+        with filetext('a,b\n1,2\n3,4', extension='csv') as csvfilename:
+            t = into('sqlite:///%s::mytable' % dbfilename,
+                     csvfilename, has_header=True)
+            assert discover(t) == dshape('var * {a: int64, b: int64}')
+            assert into(set, t) == set([(1, 2), (3, 4)])
+
+
+def test_csv_infer_header():
+    with tmpfile('db') as dbfilename:
+        with filetext('a,b\n1,2\n3,4', extension='csv') as csvfilename:
+            t = into('sqlite:///%s::mytable' % dbfilename, csvfilename)
+            assert discover(t) == dshape('var * {a: int64, b: int64}')
+            assert into(set, t) == set([(1, 2), (3, 4)])


### PR DESCRIPTION
SQLite loading uses pandas to quickly infer if a file has a header or not.