### PR TITLE
Resource function for *.csv no longer requires leading text

### DIFF
--- a/into/backends/csv.py
+++ b/into/backends/csv.py
@@ -224,7 +224,7 @@ def resource_csv(uri, **kwargs):
 
 
 from glob import glob
-@resource.register('.+\*.+', priority=12)
+@resource.register('.*\*.+', priority=12)
 def resource_glob(uri, **kwargs):
     filenames = sorted(glob(uri))
     r = resource(filenames[0], **kwargs)

--- a/into/backends/tests/test_csv.py
+++ b/into/backends/tests/test_csv.py
@@ -11,7 +11,8 @@ from collections import Iterator
 from into.backends.csv import (CSV, append, convert, resource,
         csv_to_DataFrame, CSV_to_chunks_of_dataframes, infer_header)
 from into.utils import tmpfile, filetext, filetexts, raises
-from into import into, append, convert, resource, discover, dshape, Temp
+from into import (into, append, convert, resource, discover, dshape, Temp,
+        chunks)
 from into.temp import _Temp
 from into.compatibility import unicode, skipif
 
@@ -179,6 +180,9 @@ def test_glob():
         r = resource('accounts*.csv', has_header=True)
         assert convert(list, r) == [('Alice', 100), ('Bob', 200),
                                     ('Alice', 300), ('Bob', 400)]
+
+        r = resource('*.csv')
+        assert isinstance(r, chunks(CSV))
 
 
 def test_pandas_csv_naive_behavior_results_in_columns():

--- a/into/tests/test_directory.py
+++ b/into/tests/test_directory.py
@@ -38,7 +38,7 @@ def test_resource_directory():
         assert r.path.rstrip(os.path.sep) == path.rstrip(os.path.sep)
 
         r2 = resource(os.path.join(path, '*.csv'))
-        assert type(r) == Directory(CSV)
+        assert type(r2) == Directory(CSV)
         assert r2.path.rstrip(os.path.sep) == path.rstrip(os.path.sep)
 
 


### PR DESCRIPTION
Before the regex was `.+\*.+` which due to the first `+`, did not
support `*.csv` because it didn't have anything leading up to the `*`.

We replace the `+` with a `*` to allow for zero leading characters

Fixes #85 