### PR TITLE
Migrate tables between databases through iterators

### DIFF
--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -312,6 +312,9 @@ def append_anything_to_sql_Table(t, o, **kwargs):
 
 @append.register(sa.Table, sa.sql.Select)
 def append_select_statement_to_sql_Table(t, o, **kwargs):
+    if not o.bind == t.bind:
+        return append(t, convert(Iterator, o, **kwargs), **kwargs)
+
     assert o.bind.has_table(t.name), 'tables must come from the same database'
 
     query = t.insert().from_select(o.columns.keys(), o)

--- a/into/backends/tests/test_sql.py
+++ b/into/backends/tests/test_sql.py
@@ -262,3 +262,16 @@ def test_engine_metadata_caching():
 
         assert a.metadata is b.metadata
         assert engine is a.bind is b.bind
+
+
+def test_copy_one_table_to_a_foreign_engine():
+    data = [(1, 1), (2, 4), (3, 9)]
+    ds = dshape('var * {x: int, y: int}')
+    with tmpfile('db') as fn1:
+        with tmpfile('db') as fn2:
+            src = into('sqlite:///%s::points' % fn1, data, dshape=ds)
+            tgt = into('sqlite:///%s::points' % fn2 + '::points',
+                    sa.select([src]), dshape=ds)
+
+            assert into(set, src) == into(set, tgt)
+            assert into(set, data) == into(set, tgt)


### PR DESCRIPTION
The normal Table <- Select transfer works great when the tables
are in the same database.  When transfering between databases we now
explicitly convert through Iterator