### PR TITLE
Access `args` instead of `message` on `NotImplementedError`.

### DIFF
--- a/into/backends/sql.py
+++ b/into/backends/sql.py
@@ -140,7 +140,7 @@ def discover(metadata):
                 "\nSkipping.")
         except NotImplementedError as e:
             print("Blaze does not understand a SQLAlchemy type.\n"
-                "Blaze provided the following error:\n\t%s" % e.message +
+                "Blaze provided the following error:\n\t%s" % "\n\t".join(e.args) +
                 "\nSkipping.")
     return DataShape(Record(pairs))
 


### PR DESCRIPTION
There is no `message` attribute on a `BaseException` instance, so the access in `discover` in `backends/sql.py:143`  raises an exception.