### PR TITLE
Update meta.yaml to include python version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,8 @@ package:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  string: {{ environ.get('GIT_BUILD_STR', '') }}
+  {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+  {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
   script: python setup.py install
 
 source:


### PR DESCRIPTION
This PR partially solves issue #113 by including the python version the build string name. The meta.yaml follows @tswicegood conda-recipe in:
https://github.com/conda/conda-env/blob/develop/conda.recipe/meta.yaml
