### PR TITLE
Update meta.yaml to use default conda build string

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
-  string: {{ environ.get('GIT_BUILD_STR', '') }}
   script: python setup.py install
 
 source:


### PR DESCRIPTION
Simple alternative to #112 to fix #113.

The downside is that the build string will not contain the GIT_BUILD_STR with GIT_DESCRIBE_HASH (the current commit short-hash as displayed from git describe --tags) and the GIT_DESCRIBE_NUMBER	 (string denoting the number of commits since the most recent tag).

If that was desired, the inclusions of those with the python and numpy would look something like:

```
string: py{{ environ.get('PY_VER').replace('.', '') }}{{ environ.get('CONDA_NPY').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}
```

Both solutions fix issue #113. 